### PR TITLE
Include isMarkdown feature in Text component

### DIFF
--- a/.jest/setupTests.js
+++ b/.jest/setupTests.js
@@ -28,6 +28,7 @@ copyProps(window, global)
 jest.mock('faker', () => (
   {
     random: {
+      boolean: jest.fn(() => true),
       number: jest.fn(() => 2),
       words: jest.fn(() => 'string string'),
       word: jest.fn(() => 'string')
@@ -41,6 +42,10 @@ jest.mock('faker', () => (
     },
     internet: {
       email: jest.fn(() => 'string@email.com')
+    },
+    lorem: {
+      sentence: jest.fn(() => 'string'),
+      paragraphs: jest.fn(() => 'string')
     }
   }
 ))

--- a/package-lock.json
+++ b/package-lock.json
@@ -10794,8 +10794,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10813,13 +10812,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10832,18 +10829,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10946,8 +10940,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10957,7 +10950,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10970,20 +10962,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -11000,7 +10989,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11073,8 +11061,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11084,7 +11071,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11160,8 +11146,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11191,7 +11176,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11209,7 +11193,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11248,13 +11231,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -14376,22 +14357,36 @@
       }
     },
     "markdown-to-jsx": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.8.3.tgz",
-      "integrity": "sha512-I/kRZDvHFMEoKCjFS119v6Op4R1wZJEUEwhWSNtsE7WHRVcxKrLZ9vApvNb1j80MAFIY4/e4m1f4vIwSgKUZ8g==",
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.9.4.tgz",
+      "integrity": "sha512-Fvx2ZhiknGmcLsWVjIq6MmiN9gcCot8w+jzwN2mLXZcQsJGRN3Zes5Sp5M9YNIzUy/sDyuOTjimFdtAcvvmAPQ==",
       "requires": {
         "prop-types": "^15.6.2",
         "unquote": "^1.1.0"
       },
       "dependencies": {
-        "prop-types": {
-          "version": "15.6.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-          "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
           "requires": {
-            "loose-envify": "^1.3.1",
-            "object-assign": "^4.1.1"
+            "js-tokens": "^3.0.0 || ^4.0.0"
           }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.isnumber": "^3.0.3",
     "lodash.throttle": "^4.1.1",
-    "markdown-to-jsx": "^6.8.3",
+    "markdown-to-jsx": "^6.9.4",
     "medium-editor": "^5.23.3",
     "react-avatar": "^3.5.0",
     "react-click-outside": "github:tj/react-click-outside",

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -36577,11 +36577,13 @@ exports[`Storyshots UI Components/Text/Demos content with Markdown 1`] = `
 
 It's great getting to know you! After you sign up, X-Teamers from our community review profiles and send invitations to those they see standing out.
 
-### Lorem Ipsum
+## Lorem Ipsum
 
 Due to high demand, we send out a limited number of invites each month, meaning we can't guarantee you'll hear from us about an interview.
 
-Some things that will help you stand out:
+### Sit dolor amet
+
+Some things that [will help you stand out](http://google.com):
 
 - Experience working on large scale projects with a significant user base.
 - Strong written and spoken English.

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -57,6 +57,7 @@ exports[`Storyshots Form Components/InputField Use date field with label 1`] = `
       content="Date Field"
       hasDivider={false}
       isCentered={false}
+      isMarkdown={false}
       isPureContent={false}
       required={false}
     />
@@ -102,6 +103,7 @@ exports[`Storyshots Form Components/InputField invalid element 1`] = `
       content="Invalid Field"
       hasDivider={false}
       isCentered={false}
+      isMarkdown={false}
       isPureContent={false}
       required={false}
     />
@@ -163,6 +165,7 @@ exports[`Storyshots Form Components/InputField required element 1`] = `
       content="Required Field"
       hasDivider={false}
       isCentered={false}
+      isMarkdown={false}
       isPureContent={false}
       required={true}
     />
@@ -200,6 +203,7 @@ exports[`Storyshots Form Components/InputField standard use (text input element 
       content="First Name"
       hasDivider={false}
       isCentered={false}
+      isMarkdown={false}
       isPureContent={false}
       required={false}
     />
@@ -226,6 +230,7 @@ exports[`Storyshots Form Components/InputField standard use (text input element 
       content="First Name"
       hasDivider={false}
       isCentered={false}
+      isMarkdown={false}
       isPureContent={false}
       required={false}
     />
@@ -252,6 +257,7 @@ exports[`Storyshots Form Components/InputField standard use (with \`label\` and 
       content="How many years of experience do you have?"
       hasDivider={false}
       isCentered={false}
+      isMarkdown={false}
       isPureContent={false}
       required={false}
     />
@@ -274,6 +280,7 @@ exports[`Storyshots Form Components/InputField standard use (with \`label\` and 
       content="years"
       hasDivider={false}
       isCentered={false}
+      isMarkdown={false}
       isPureContent={true}
       required={false}
     />
@@ -303,6 +310,7 @@ exports[`Storyshots Form Components/InputField standard use (with only \`postTex
       content="years"
       hasDivider={false}
       isCentered={false}
+      isMarkdown={false}
       isPureContent={true}
       required={false}
     />
@@ -319,6 +327,7 @@ exports[`Storyshots Form Components/InputField textarea element 1`] = `
       content="What’s your availability like right now? If you’re employed and would need to give a notice, how long would that take?"
       hasDivider={false}
       isCentered={false}
+      isMarkdown={false}
       isPureContent={false}
       required={false}
     />
@@ -346,6 +355,7 @@ exports[`Storyshots Form Components/InputField textarea element, lines limit set
       content="Which skills have you used professionally?"
       hasDivider={false}
       isCentered={false}
+      isMarkdown={false}
       isPureContent={false}
       required={false}
     />
@@ -3050,6 +3060,7 @@ exports[`Storyshots UI Components/ApplicantScreen standard use 1`] = `
       content="We’d love to start to get to know more about you. Please fill out these quick questions so we can introduce you to an Ambassador who will work with you 1-on-1 to get qualified to become an X-Teamer."
       hasDivider={false}
       isCentered={false}
+      isMarkdown={false}
       isPureContent={true}
       required={false}
     />
@@ -3095,6 +3106,7 @@ exports[`Storyshots UI Components/ApplicantScreen with milestones injected 1`] =
         hasDivider={false}
         heading="So it begins."
         isCentered={false}
+        isMarkdown={false}
         isPureContent={false}
         required={false}
       />
@@ -4977,6 +4989,36 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
     key="14"
     style={
       Object {
+        "backgroundColor": "rgb(246, 57, 84)",
+      }
+    }
+  >
+    <div
+      className="AutoUI_ui_ColorPalette-34"
+    >
+      typoAnchor
+    </div>
+  </div>
+  <div
+    className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
+    key="15"
+    style={
+      Object {
+        "backgroundColor": "rgb(242, 11, 44)",
+      }
+    }
+  >
+    <div
+      className="AutoUI_ui_ColorPalette-34"
+    >
+      typoAnchorHover
+    </div>
+  </div>
+  <div
+    className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
+    key="16"
+    style={
+      Object {
         "backgroundColor": "rgb(52, 50, 59)",
       }
     }
@@ -4989,7 +5031,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="15"
+    key="17"
     style={
       Object {
         "backgroundColor": "rgb(184, 183, 188)",
@@ -5004,7 +5046,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="16"
+    key="18"
     style={
       Object {
         "backgroundColor": "rgb(19, 14, 46)",
@@ -5019,7 +5061,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="17"
+    key="19"
     style={
       Object {
         "backgroundColor": "rgb(90, 86, 101)",
@@ -5034,7 +5076,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="18"
+    key="20"
     style={
       Object {
         "backgroundColor": "rgb(178, 182, 188)",
@@ -5049,7 +5091,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="19"
+    key="21"
     style={
       Object {
         "backgroundColor": "rgb(178, 182, 188)",
@@ -5064,7 +5106,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="20"
+    key="22"
     style={
       Object {
         "backgroundColor": "rgb(240, 241, 244)",
@@ -5079,7 +5121,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="21"
+    key="23"
     style={
       Object {
         "backgroundColor": "rgb(145, 140, 160)",
@@ -5094,7 +5136,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="22"
+    key="24"
     style={
       Object {
         "backgroundColor": "rgb(52, 50, 59)",
@@ -5109,7 +5151,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="23"
+    key="25"
     style={
       Object {
         "backgroundColor": "rgb(230, 230, 237)",
@@ -5124,7 +5166,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="24"
+    key="26"
     style={
       Object {
         "backgroundColor": "rgb(211, 47, 59)",
@@ -5139,7 +5181,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="25"
+    key="27"
     style={
       Object {
         "backgroundColor": "rgb(247, 217, 220)",
@@ -5154,7 +5196,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="26"
+    key="28"
     style={
       Object {
         "backgroundColor": "rgb(246, 57, 84)",
@@ -5169,7 +5211,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="27"
+    key="29"
     style={
       Object {
         "backgroundColor": "rgb(228, 228, 228)",
@@ -5184,7 +5226,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="28"
+    key="30"
     style={
       Object {
         "backgroundColor": "rgb(233, 237, 238)",
@@ -5199,7 +5241,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="29"
+    key="31"
     style={
       Object {
         "backgroundColor": "rgb(240, 241, 244)",
@@ -5214,7 +5256,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="30"
+    key="32"
     style={
       Object {
         "backgroundColor": "rgb(230, 230, 237)",
@@ -5229,7 +5271,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="31"
+    key="33"
     style={
       Object {
         "backgroundColor": "rgb(246, 57, 84)",
@@ -5244,7 +5286,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="32"
+    key="34"
     style={
       Object {
         "backgroundColor": "rgb(255, 255, 255)",
@@ -5259,7 +5301,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="33"
+    key="35"
     style={
       Object {
         "backgroundColor": "rgb(52, 50, 59)",
@@ -5274,7 +5316,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="34"
+    key="36"
     style={
       Object {
         "backgroundColor": "rgb(178, 182, 188)",
@@ -5289,7 +5331,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="35"
+    key="37"
     style={
       Object {
         "backgroundColor": "rgb(52, 50, 59)",
@@ -5304,7 +5346,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="36"
+    key="38"
     style={
       Object {
         "backgroundColor": "rgb(240, 241, 244)",
@@ -5319,7 +5361,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="37"
+    key="39"
     style={
       Object {
         "backgroundColor": "rgb(92, 87, 101)",
@@ -5334,7 +5376,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="38"
+    key="40"
     style={
       Object {
         "backgroundColor": "rgb(184, 183, 188)",
@@ -5349,7 +5391,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="39"
+    key="41"
     style={
       Object {
         "backgroundColor": "rgb(179, 179, 179)",
@@ -5364,7 +5406,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="40"
+    key="42"
     style={
       Object {
         "backgroundColor": "rgb(95, 207, 33)",
@@ -5379,7 +5421,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="41"
+    key="43"
     style={
       Object {
         "backgroundColor": "rgb(248, 231, 28)",
@@ -5394,7 +5436,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="42"
+    key="44"
     style={
       Object {
         "backgroundColor": "rgb(246, 57, 84)",
@@ -5409,7 +5451,7 @@ exports[`Storyshots UI Components/ColorPalette color variables for development r
   </div>
   <div
     className="AutoUI_ui_ColorPalette-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="43"
+    key="45"
     style={
       Object {
         "backgroundColor": "rgb(196, 196, 196)",
@@ -11344,7 +11386,9 @@ exports[`Storyshots UI Components/Email HTML body test 1`] = `
   <div
     className="AutoUI_ui_Email-88 AutoUI_typo-53 AutoUI_typo-40"
   >
-    <span>
+    <span
+      key="outer"
+    >
       <font
         key="0"
         size="6"
@@ -11760,7 +11804,9 @@ exports[`Storyshots UI Components/Email initial open body 1`] = `
   <div
     className="AutoUI_ui_Email-88 AutoUI_typo-53 AutoUI_typo-40"
   >
-    <span>
+    <span
+      key="outer"
+    >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque tempus molestie purus sed suscipit. Duis non ultricies velit, eu laoreet augue. Nullam turpis massa, scelerisque at tempus eu, placerat vitae orci. Nam at sem pellentesque, viverra risus id, volutpat nisl. In hac habitasse platea dictumst. Integer et dignissim eros. Quisque vel sem vel magna congue consectetur ac vel ex. Pellentesque pulvinar congue lacinia. Sed finibus ex non lorem sodales, ac pulvinar urna placerat. Aenean vel sodales libero, ac egestas velit. Nulla turpis dolor, dapibus ut diam sed, aliquam vestibulum nibh. In a ullamcorper libero. Pellentesque mattis, dui in molestie cursus, est risus convallis ligula, nec hendrerit sem odio eu elit. Aliquam sapien lacus, tincidunt rhoncus malesuada at, finibus non dolor. Pellentesque interdum nibh eu tempor pretium.
     </span>
   </div>
@@ -11827,7 +11873,9 @@ exports[`Storyshots UI Components/Email initial open body and content with lineb
   <div
     className="AutoUI_ui_Email-88 AutoUI_typo-53 AutoUI_typo-40"
   >
-    <div>
+    <div
+      key="outer"
+    >
       <p
         key="0"
       >
@@ -13961,6 +14009,7 @@ exports[`Storyshots UI Components/EmailFeed with error message 1`] = `
     }
     hasDivider={true}
     isCentered={true}
+    isMarkdown={false}
     isPureContent={false}
     required={false}
   />
@@ -14018,6 +14067,7 @@ exports[`Storyshots UI Components/EmailFeed with error message and refresh butto
     }
     hasDivider={true}
     isCentered={true}
+    isMarkdown={false}
     isPureContent={false}
     required={false}
   />
@@ -18500,6 +18550,7 @@ exports[`Storyshots UI Components/MilestonesScreen first step 1`] = `
           hasDivider={false}
           heading="First step"
           isCentered={false}
+          isMarkdown={false}
           isPureContent={false}
           required={false}
         />
@@ -18562,6 +18613,7 @@ exports[`Storyshots UI Components/MilestonesScreen n-th step 1`] = `
           hasDivider={false}
           heading="First subsection"
           isCentered={false}
+          isMarkdown={false}
           isPureContent={false}
           required={false}
         />
@@ -18599,6 +18651,7 @@ exports[`Storyshots UI Components/MilestonesScreen n-th step 1`] = `
           hasDivider={false}
           heading="Second subsection"
           isCentered={false}
+          isMarkdown={false}
           isPureContent={false}
           required={false}
         />
@@ -18636,6 +18689,7 @@ exports[`Storyshots UI Components/MilestonesScreen n-th step 1`] = `
           hasDivider={false}
           heading="Third subsection"
           isCentered={false}
+          isMarkdown={false}
           isPureContent={false}
           required={false}
         />
@@ -18686,6 +18740,7 @@ exports[`Storyshots UI Components/MilestonesScreen second step 1`] = `
           hasDivider={false}
           heading="First subsection"
           isCentered={false}
+          isMarkdown={false}
           isPureContent={false}
           required={false}
         />
@@ -18723,6 +18778,7 @@ exports[`Storyshots UI Components/MilestonesScreen second step 1`] = `
           hasDivider={false}
           heading="Second subsection"
           isCentered={false}
+          isMarkdown={false}
           isPureContent={false}
           required={false}
         />
@@ -20498,6 +20554,7 @@ exports[`Storyshots UI Components/RoadmapHero basic usage 1`] = `
       heading="Your roadmap to X‑Team"
       headingType="mainHeading"
       isCentered={false}
+      isMarkdown={false}
       isPureContent={false}
       required={false}
     />
@@ -20522,6 +20579,7 @@ exports[`Storyshots UI Components/RoadmapHero missing props (does component expl
       hasDivider={true}
       headingType="mainHeading"
       isCentered={false}
+      isMarkdown={false}
       isPureContent={false}
       required={false}
     />
@@ -20548,6 +20606,7 @@ exports[`Storyshots UI Components/RoadmapHero with image url in props 1`] = `
       heading="Next Steps"
       headingType="mainHeading"
       isCentered={false}
+      isMarkdown={false}
       isPureContent={false}
       required={false}
     />
@@ -20573,6 +20632,7 @@ exports[`Storyshots UI Components/RoadmapLevel active state 1`] = `
     content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consectetur, fuga suscipit rem voluptatibus sunt sapiente. Molestiae aliquam at libero repellat, asperiores, recusandae, praesentium ratione officia molestias nobis temporibus ipsam, repudiandae!"
     hasDivider={false}
     isCentered={false}
+    isMarkdown={false}
     isPureContent={false}
     level="Level 1"
     required={false}
@@ -20594,6 +20654,7 @@ exports[`Storyshots UI Components/RoadmapLevel basic usage 1`] = `
     content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consectetur, fuga suscipit rem voluptatibus sunt sapiente. Molestiae aliquam at libero repellat, asperiores, recusandae, praesentium ratione officia molestias nobis temporibus ipsam, repudiandae!"
     hasDivider={false}
     isCentered={false}
+    isMarkdown={false}
     isPureContent={false}
     level="Level 1"
     required={false}
@@ -20615,6 +20676,7 @@ exports[`Storyshots UI Components/RoadmapLevel centered state with CTA button 1`
     content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consectetur, fuga suscipit rem voluptatibus sunt sapiente. Molestiae aliquam at libero repellat, asperiores, recusandae, praesentium ratione officia molestias nobis temporibus ipsam, repudiandae!"
     hasDivider={false}
     isCentered={true}
+    isMarkdown={false}
     isPureContent={false}
     level="Level 1"
     required={false}
@@ -33684,6 +33746,7 @@ exports[`Storyshots UI Components/SettingsImportScreen default initial view 1`] 
     hasDivider={true}
     heading="Import"
     isCentered={true}
+    isMarkdown={false}
     isPureContent={false}
     required={false}
   />
@@ -33732,6 +33795,7 @@ exports[`Storyshots UI Components/SettingsImportScreen imported view 1`] = `
     hasDivider={true}
     heading="Import"
     isCentered={true}
+    isMarkdown={false}
     isPureContent={false}
     required={false}
   />
@@ -33802,6 +33866,7 @@ exports[`Storyshots UI Components/SettingsImportScreen imported view with server
     hasDivider={true}
     heading="Import"
     isCentered={true}
+    isMarkdown={false}
     isPureContent={false}
     required={false}
   />
@@ -33825,6 +33890,7 @@ exports[`Storyshots UI Components/SettingsImportScreen importing view 1`] = `
     hasDivider={true}
     heading="Import"
     isCentered={true}
+    isMarkdown={false}
     isPureContent={false}
     required={false}
   />
@@ -33868,6 +33934,7 @@ exports[`Storyshots UI Components/SettingsImportScreen validated view containing
     hasDivider={true}
     heading="Import"
     isCentered={true}
+    isMarkdown={false}
     isPureContent={false}
     required={false}
   />
@@ -33947,6 +34014,7 @@ exports[`Storyshots UI Components/SettingsImportScreen validated view containing
     hasDivider={true}
     heading="Import"
     isCentered={true}
+    isMarkdown={false}
     isPureContent={false}
     required={false}
   />
@@ -36396,13 +36464,35 @@ exports[`Storyshots UI Components/Tabs one tab 1`] = `
 </section>
 `;
 
-exports[`Storyshots UI Components/Text content with HTML tags 1`] = `
+exports[`Storyshots UI Components/Text showcase (use knobs) 1`] = `
+<Text
+  content="string"
+  hasDivider={true}
+  heading="string"
+  headingType="divider"
+  isCentered={true}
+  isMarkdown={false}
+  isPureContent={false}
+  level="string"
+  required={true}
+  subHeading="string"
+  subHeadingType="divider"
+/>
+`;
+
+exports[`Storyshots UI Components/Text/Debug missing props (does component explode?) 1`] = `
 <section
-  className="AutoUI_ui_Text-29"
+  className="AutoUI_ui_Text-33"
 >
   <div
-    className="AutoUI_ui_Text-43 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-  >
+    className="AutoUI_ui_Text-47 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
+  />
+</section>
+`;
+
+exports[`Storyshots UI Components/Text/Demos content with HTML tags 1`] = `
+<Text
+  content={
     <div>
       <h1>
         H1
@@ -36472,266 +36562,228 @@ exports[`Storyshots UI Components/Text content with HTML tags 1`] = `
          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas scelerisque vestibulum sem id cursus. Fusce nec consequat erat. Praesent convallis aliquet augue, vel lacinia urna pretium eu. Morbi accumsan neque sit amet feugiat molestie. Aliquam erat volutpat. Cras quis dapibus risus. Proin luctus hendrerit semper. Donec finibus hendrerit ante at egestas.
       </p>
     </div>
-  </div>
-</section>
+  }
+  hasDivider={false}
+  isCentered={false}
+  isMarkdown={false}
+  isPureContent={false}
+  required={false}
+/>
 `;
 
-exports[`Storyshots UI Components/Text empty text example  1`] = `
-<section
-  className="AutoUI_ui_Text-29"
->
-  <div
-    className="AutoUI_ui_Text-43 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-  />
-</section>
+exports[`Storyshots UI Components/Text/Demos content with Markdown 1`] = `
+<Text
+  content="# Time to show off.
+
+It's great getting to know you! After you sign up, X-Teamers from our community review profiles and send invitations to those they see standing out.
+
+### Lorem Ipsum
+
+Due to high demand, we send out a limited number of invites each month, meaning we can't guarantee you'll hear from us about an interview.
+
+Some things that will help you stand out:
+
+- Experience working on large scale projects with a significant user base.
+- Strong written and spoken English.
+- A LinkedIn profile that details the projects you've worked on.
+- Availability for long-term fulltime contracts (the average contract duration is 10 months).
+
+This is _**custom content**_ btw"
+  hasDivider={false}
+  isCentered={false}
+  isMarkdown={true}
+  isPureContent={false}
+  required={false}
+/>
 `;
 
-exports[`Storyshots UI Components/Text heading 1`] = `
-<section
-  className="AutoUI_ui_Text-29"
->
-  <h1
-    className="undefined AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22"
-  >
-    Your roadmap to X-Team
-  </h1>
-  <div
-    className="AutoUI_ui_Text-43 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-  >
-    Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.
-  </div>
-</section>
+exports[`Storyshots UI Components/Text/Demos heading 1`] = `
+<Text
+  content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
+  hasDivider={false}
+  heading="Your roadmap to X-Team"
+  isCentered={false}
+  isMarkdown={false}
+  isPureContent={false}
+  required={false}
+/>
 `;
 
-exports[`Storyshots UI Components/Text heading with center align 1`] = `
-<section
-  className="AutoUI_ui_Text-29 AutoUI_ui_Text-50"
->
-  <h1
-    className="undefined AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22"
-  >
-    Your roadmap to X-Team
-  </h1>
-  <div
-    className="AutoUI_ui_Text-43 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-  >
-    Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.
-  </div>
-</section>
+exports[`Storyshots UI Components/Text/Demos heading and sub heading with divider 1`] = `
+<Text
+  content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
+  hasDivider={true}
+  heading="Your roadmap to X-Team"
+  isCentered={false}
+  isMarkdown={false}
+  isPureContent={false}
+  required={false}
+  subHeading="Your roadmap to X-Team"
+/>
 `;
 
-exports[`Storyshots UI Components/Text heading with center align and divider 1`] = `
-<section
-  className="AutoUI_ui_Text-29 AutoUI_ui_Text-50"
->
-  <h1
-    className="undefined AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22"
-  >
-    Your roadmap to X-Team
-  </h1>
-  <span
-    className="AutoUI_ui_Text-41 AutoUI_typo-192 AutoUI_ui_Text-52"
-  />
-  <div
-    className="AutoUI_ui_Text-43 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-  >
-    Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.
-  </div>
-</section>
+exports[`Storyshots UI Components/Text/Demos heading with center align 1`] = `
+<Text
+  content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
+  hasDivider={false}
+  heading="Your roadmap to X-Team"
+  isCentered={true}
+  isMarkdown={false}
+  isPureContent={false}
+  required={false}
+/>
 `;
 
-exports[`Storyshots UI Components/Text heading with divider 1`] = `
-<section
-  className="AutoUI_ui_Text-29"
->
-  <h1
-    className="undefined AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22"
-  >
-    Your roadmap to X-Team
-  </h1>
-  <span
-    className="AutoUI_ui_Text-41 AutoUI_typo-192"
-  />
-  <div
-    className="AutoUI_ui_Text-43 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-  >
-    Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.
-  </div>
-</section>
+exports[`Storyshots UI Components/Text/Demos heading with center align and divider 1`] = `
+<Text
+  content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
+  hasDivider={true}
+  heading="Your roadmap to X-Team"
+  isCentered={true}
+  isMarkdown={false}
+  isPureContent={false}
+  required={false}
+/>
 `;
 
-exports[`Storyshots UI Components/Text heading with divider and no content 1`] = `
-<section
-  className="AutoUI_ui_Text-29"
->
-  <h1
-    className="undefined AutoUI_typo-91 AutoUI_typo-53 AutoUI_typo-22"
-  >
-    Your roadmap to X-Team
-  </h1>
-  <span
-    className="AutoUI_ui_Text-41 AutoUI_typo-192"
-  />
-  <div
-    className="AutoUI_ui_Text-43 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-  />
-</section>
+exports[`Storyshots UI Components/Text/Demos heading with divider 1`] = `
+<Text
+  content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
+  hasDivider={true}
+  heading="Your roadmap to X-Team"
+  isCentered={false}
+  isMarkdown={false}
+  isPureContent={false}
+  required={false}
+/>
 `;
 
-exports[`Storyshots UI Components/Text pure content with no wrappers around 1`] = `
-<span
-  className="AutoUI_ui_Text-48 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
->
-  Just a sample text
-</span>
+exports[`Storyshots UI Components/Text/Demos heading with divider and no content 1`] = `
+<Text
+  hasDivider={true}
+  heading="Your roadmap to X-Team"
+  isCentered={false}
+  isMarkdown={false}
+  isPureContent={false}
+  required={false}
+/>
 `;
 
-exports[`Storyshots UI Components/Text pure content with no wrappers around and Required 1`] = `
-<span
-  className="AutoUI_ui_Text-48 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_Text-57"
->
-  Just a required text
-</span>
+exports[`Storyshots UI Components/Text/Demos pure content with no wrappers around 1`] = `
+<Text
+  content="Just a sample text"
+  hasDivider={false}
+  isCentered={false}
+  isMarkdown={false}
+  isPureContent={true}
+  required={false}
+/>
 `;
 
-exports[`Storyshots UI Components/Text required 1`] = `
-<section
-  className="AutoUI_ui_Text-29"
->
-  <div
-    className="AutoUI_ui_Text-43 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 AutoUI_ui_Text-57"
-  >
-    Just a required text
-  </div>
-</section>
+exports[`Storyshots UI Components/Text/Demos pure content with no wrappers around and Required 1`] = `
+<Text
+  content="Just a required text"
+  hasDivider={false}
+  isCentered={false}
+  isMarkdown={false}
+  isPureContent={true}
+  required={true}
+/>
 `;
 
-exports[`Storyshots UI Components/Text sub Heading with center align 1`] = `
-<section
-  className="AutoUI_ui_Text-29 AutoUI_ui_Text-50"
->
-  <h2
-    className="undefined AutoUI_typo-132 AutoUI_typo-53 AutoUI_typo-22"
-  >
-    Your roadmap to X-Team
-  </h2>
-  <div
-    className="AutoUI_ui_Text-43 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-  >
-    Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.
-  </div>
-</section>
+exports[`Storyshots UI Components/Text/Demos required 1`] = `
+<Text
+  content="Just a required text"
+  hasDivider={false}
+  isCentered={false}
+  isMarkdown={false}
+  isPureContent={false}
+  required={true}
+/>
 `;
 
-exports[`Storyshots UI Components/Text sub Heading with divider 1`] = `
-<section
-  className="AutoUI_ui_Text-29"
->
-  <h2
-    className="undefined AutoUI_typo-132 AutoUI_typo-53 AutoUI_typo-22"
-  >
-    Your roadmap to X-Team
-  </h2>
-  <span
-    className="AutoUI_ui_Text-41 AutoUI_typo-192"
-  />
-  <div
-    className="AutoUI_ui_Text-43 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-  >
-    Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.
-  </div>
-</section>
+exports[`Storyshots UI Components/Text/Demos sub Heading with center align 1`] = `
+<Text
+  content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
+  hasDivider={false}
+  isCentered={true}
+  isMarkdown={false}
+  isPureContent={false}
+  required={false}
+  subHeading="Your roadmap to X-Team"
+/>
 `;
 
-exports[`Storyshots UI Components/Text sub Heading with level 1`] = `
-<section
-  className="AutoUI_ui_Text-29"
->
-  <h2
-    className="undefined AutoUI_typo-132 AutoUI_typo-53 AutoUI_typo-22"
-  >
-    Your roadmap to X-Team
-  </h2>
-  <p
-    className="undefined AutoUI_typo-146 AutoUI_typo-53 AutoUI_typo-28"
-  >
-    Level 7
-  </p>
-  <div
-    className="AutoUI_ui_Text-43 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-  >
-    Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.
-  </div>
-</section>
+exports[`Storyshots UI Components/Text/Demos sub Heading with divider 1`] = `
+<Text
+  content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
+  hasDivider={true}
+  isCentered={false}
+  isMarkdown={false}
+  isPureContent={false}
+  required={false}
+  subHeading="Your roadmap to X-Team"
+/>
 `;
 
-exports[`Storyshots UI Components/Text sub Heading with level and center align 1`] = `
-<section
-  className="AutoUI_ui_Text-29 AutoUI_ui_Text-50"
->
-  <h2
-    className="undefined AutoUI_typo-132 AutoUI_typo-53 AutoUI_typo-22"
-  >
-    Your roadmap to X-Team
-  </h2>
-  <p
-    className="undefined AutoUI_typo-146 AutoUI_typo-53 AutoUI_typo-28"
-  >
-    Level 7
-  </p>
-  <div
-    className="AutoUI_ui_Text-43 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-  >
-    Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.
-  </div>
-</section>
+exports[`Storyshots UI Components/Text/Demos sub Heading with level 1`] = `
+<Text
+  content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
+  hasDivider={false}
+  isCentered={false}
+  isMarkdown={false}
+  isPureContent={false}
+  level="Level 7"
+  required={false}
+  subHeading="Your roadmap to X-Team"
+/>
 `;
 
-exports[`Storyshots UI Components/Text sub heading 1`] = `
-<section
-  className="AutoUI_ui_Text-29"
->
-  <h2
-    className="undefined AutoUI_typo-132 AutoUI_typo-53 AutoUI_typo-22"
-  >
-    Your roadmap to X-Team
-  </h2>
-  <div
-    className="AutoUI_ui_Text-43 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-  >
-    Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.
-  </div>
-</section>
+exports[`Storyshots UI Components/Text/Demos sub Heading with level and center align 1`] = `
+<Text
+  content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
+  hasDivider={false}
+  isCentered={true}
+  isMarkdown={false}
+  isPureContent={false}
+  level="Level 7"
+  required={false}
+  subHeading="Your roadmap to X-Team"
+/>
 `;
 
-exports[`Storyshots UI Components/Text without Heading and Sub Heading with divider 1`] = `
-<section
-  className="AutoUI_ui_Text-29"
->
-  <span
-    className="AutoUI_ui_Text-41 AutoUI_typo-192"
-  />
-  <div
-    className="AutoUI_ui_Text-43 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-  >
-    Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.
-  </div>
-</section>
+exports[`Storyshots UI Components/Text/Demos sub heading 1`] = `
+<Text
+  content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
+  hasDivider={false}
+  isCentered={false}
+  isMarkdown={false}
+  isPureContent={false}
+  required={false}
+  subHeading="Your roadmap to X-Team"
+/>
 `;
 
-exports[`Storyshots UI Components/Text without Heading and Sub Heading with isCentered align 1`] = `
-<section
-  className="AutoUI_ui_Text-29 AutoUI_ui_Text-50"
->
-  <span
-    className="AutoUI_ui_Text-41 AutoUI_typo-192 AutoUI_ui_Text-52"
-  />
-  <div
-    className="AutoUI_ui_Text-43 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-  >
-    Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.
-  </div>
-</section>
+exports[`Storyshots UI Components/Text/Demos without Heading and Sub Heading with divider 1`] = `
+<Text
+  content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
+  hasDivider={true}
+  isCentered={false}
+  isMarkdown={false}
+  isPureContent={false}
+  required={false}
+/>
+`;
+
+exports[`Storyshots UI Components/Text/Demos without Heading and Sub Heading with isCentered align 1`] = `
+<Text
+  content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
+  hasDivider={true}
+  isCentered={true}
+  isMarkdown={false}
+  isPureContent={false}
+  required={false}
+/>
 `;
 
 exports[`Storyshots UI Components/TextareaEditor basic usage 1`] = `
@@ -38316,6 +38368,21 @@ exports[`Storyshots UI Components/Typography typography sets for development ref
       className="AutoUI_ui_Typography-41"
     >
       formText
+    </div>
+  </div>
+  <div
+    className="AutoUI_ui_Typography-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
+    key="9"
+  >
+    <span
+      className="AutoUI_ui_Typography-35 AutoUI_typo-192"
+    >
+      The quick brown fox jumps over the lazy dog
+    </span>
+    <div
+      className="AutoUI_ui_Typography-41"
+    >
+      divider
     </div>
   </div>
 </section>

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -38370,21 +38370,6 @@ exports[`Storyshots UI Components/Typography typography sets for development ref
       formText
     </div>
   </div>
-  <div
-    className="AutoUI_ui_Typography-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
-    key="9"
-  >
-    <span
-      className="AutoUI_ui_Typography-35 AutoUI_typo-192"
-    >
-      The quick brown fox jumps over the lazy dog
-    </span>
-    <div
-      className="AutoUI_ui_Typography-41"
-    >
-      divider
-    </div>
-  </div>
 </section>
 `;
 

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -56,10 +56,12 @@ exports[`Storyshots Form Components/InputField Use date field with label 1`] = `
     <Text
       content="Date Field"
       hasDivider={false}
+      headingType="headline"
       isCentered={false}
       isMarkdown={false}
       isPureContent={false}
       required={false}
+      subHeadingType="heading"
     />
     <div
       className="AutoUI_forms_InputField-152"
@@ -102,10 +104,12 @@ exports[`Storyshots Form Components/InputField invalid element 1`] = `
     <Text
       content="Invalid Field"
       hasDivider={false}
+      headingType="headline"
       isCentered={false}
       isMarkdown={false}
       isPureContent={false}
       required={false}
+      subHeadingType="heading"
     />
     <input
       aria-labelledby="label-invalid"
@@ -164,10 +168,12 @@ exports[`Storyshots Form Components/InputField required element 1`] = `
     <Text
       content="Required Field"
       hasDivider={false}
+      headingType="headline"
       isCentered={false}
       isMarkdown={false}
       isPureContent={false}
       required={true}
+      subHeadingType="heading"
     />
     <input
       aria-labelledby="label-required"
@@ -202,10 +208,12 @@ exports[`Storyshots Form Components/InputField standard use (text input element 
     <Text
       content="First Name"
       hasDivider={false}
+      headingType="headline"
       isCentered={false}
       isMarkdown={false}
       isPureContent={false}
       required={false}
+      subHeadingType="heading"
     />
     <input
       aria-labelledby="label-name"
@@ -229,10 +237,12 @@ exports[`Storyshots Form Components/InputField standard use (text input element 
     <Text
       content="First Name"
       hasDivider={false}
+      headingType="headline"
       isCentered={false}
       isMarkdown={false}
       isPureContent={false}
       required={false}
+      subHeadingType="heading"
     />
     <input
       aria-labelledby="label-name"
@@ -256,10 +266,12 @@ exports[`Storyshots Form Components/InputField standard use (with \`label\` and 
     <Text
       content="How many years of experience do you have?"
       hasDivider={false}
+      headingType="headline"
       isCentered={false}
       isMarkdown={false}
       isPureContent={false}
       required={false}
+      subHeadingType="heading"
     />
     <input
       aria-labelledby="label-experience"
@@ -279,10 +291,12 @@ exports[`Storyshots Form Components/InputField standard use (with \`label\` and 
     <Text
       content="years"
       hasDivider={false}
+      headingType="headline"
       isCentered={false}
       isMarkdown={false}
       isPureContent={true}
       required={false}
+      subHeadingType="heading"
     />
   </label>
 </div>
@@ -309,10 +323,12 @@ exports[`Storyshots Form Components/InputField standard use (with only \`postTex
     <Text
       content="years"
       hasDivider={false}
+      headingType="headline"
       isCentered={false}
       isMarkdown={false}
       isPureContent={true}
       required={false}
+      subHeadingType="heading"
     />
   </div>
 </div>
@@ -326,10 +342,12 @@ exports[`Storyshots Form Components/InputField textarea element 1`] = `
     <Text
       content="What’s your availability like right now? If you’re employed and would need to give a notice, how long would that take?"
       hasDivider={false}
+      headingType="headline"
       isCentered={false}
       isMarkdown={false}
       isPureContent={false}
       required={false}
+      subHeadingType="heading"
     />
     <WithAutosize(Component)
       aria-labelledby="label-availability"
@@ -354,10 +372,12 @@ exports[`Storyshots Form Components/InputField textarea element, lines limit set
     <Text
       content="Which skills have you used professionally?"
       hasDivider={false}
+      headingType="headline"
       isCentered={false}
       isMarkdown={false}
       isPureContent={false}
       required={false}
+      subHeadingType="heading"
     />
     <WithAutosize(Component)
       aria-labelledby="label-skills"
@@ -3059,10 +3079,12 @@ exports[`Storyshots UI Components/ApplicantScreen standard use 1`] = `
     <Text
       content="We’d love to start to get to know more about you. Please fill out these quick questions so we can introduce you to an Ambassador who will work with you 1-on-1 to get qualified to become an X-Teamer."
       hasDivider={false}
+      headingType="headline"
       isCentered={false}
       isMarkdown={false}
       isPureContent={true}
       required={false}
+      subHeadingType="heading"
     />
   </div>
 </div>
@@ -3105,10 +3127,12 @@ exports[`Storyshots UI Components/ApplicantScreen with milestones injected 1`] =
         content="Let’s kick things off with a warmup. To proceed, click the button below to download a short programming challenge. You can bookmark this page for later access."
         hasDivider={false}
         heading="So it begins."
+        headingType="headline"
         isCentered={false}
         isMarkdown={false}
         isPureContent={false}
         required={false}
+        subHeadingType="heading"
       />
     </MilestonesScreen>
   </div>
@@ -14008,10 +14032,12 @@ exports[`Storyshots UI Components/EmailFeed with error message 1`] = `
       </span>
     }
     hasDivider={true}
+    headingType="headline"
     isCentered={true}
     isMarkdown={false}
     isPureContent={false}
     required={false}
+    subHeadingType="heading"
   />
 </Fragment>
 `;
@@ -14066,10 +14092,12 @@ exports[`Storyshots UI Components/EmailFeed with error message and refresh butto
       </span>
     }
     hasDivider={true}
+    headingType="headline"
     isCentered={true}
     isMarkdown={false}
     isPureContent={false}
     required={false}
+    subHeadingType="heading"
   />
 </Fragment>
 `;
@@ -18549,10 +18577,12 @@ exports[`Storyshots UI Components/MilestonesScreen first step 1`] = `
           content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Saepe illo error hic, nemo nostrum iusto recusandae repudiandae eum doloremque necessitatibus doloribus? Provident perferendis illo totam ipsum ut sapiente, assumenda quasi!"
           hasDivider={false}
           heading="First step"
+          headingType="headline"
           isCentered={false}
           isMarkdown={false}
           isPureContent={false}
           required={false}
+          subHeadingType="heading"
         />
         <div>
           <Button
@@ -18612,10 +18642,12 @@ exports[`Storyshots UI Components/MilestonesScreen n-th step 1`] = `
           content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. At suscipit dicta aliquam sint libero minima officiis alias ducimus. Fugit praesentium itaque, iure molestias aut beatae odit facilis inventore doloremque eaque."
           hasDivider={false}
           heading="First subsection"
+          headingType="headline"
           isCentered={false}
           isMarkdown={false}
           isPureContent={false}
           required={false}
+          subHeadingType="heading"
         />
         <div>
           <Button
@@ -18650,10 +18682,12 @@ exports[`Storyshots UI Components/MilestonesScreen n-th step 1`] = `
           content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tempora neque iusto quisquam, sed eius optio. Obcaecati, hic! Possimus sit magnam vero laboriosam obcaecati nostrum a molestiae amet aut. Corrupti, voluptas."
           hasDivider={false}
           heading="Second subsection"
+          headingType="headline"
           isCentered={false}
           isMarkdown={false}
           isPureContent={false}
           required={false}
+          subHeadingType="heading"
         />
         <div>
           <Button
@@ -18688,10 +18722,12 @@ exports[`Storyshots UI Components/MilestonesScreen n-th step 1`] = `
           content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Impedit minima aperiam dolorem natus repudiandae reprehenderit neque laudantium quasi voluptates architecto, ratione asperiores odio hic rerum alias dolores quo sint culpa!"
           hasDivider={false}
           heading="Third subsection"
+          headingType="headline"
           isCentered={false}
           isMarkdown={false}
           isPureContent={false}
           required={false}
+          subHeadingType="heading"
         />
         <div>
           <Button
@@ -18739,10 +18775,12 @@ exports[`Storyshots UI Components/MilestonesScreen second step 1`] = `
           content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Earum numquam, beatae, distinctio fugiat eveniet harum, vel sint odit adipisci quos nam soluta pariatur, voluptatibus repudiandae hic mollitia ex iste rem."
           hasDivider={false}
           heading="First subsection"
+          headingType="headline"
           isCentered={false}
           isMarkdown={false}
           isPureContent={false}
           required={false}
+          subHeadingType="heading"
         />
         <div>
           <Button
@@ -18777,10 +18815,12 @@ exports[`Storyshots UI Components/MilestonesScreen second step 1`] = `
           content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nobis ipsa illum placeat aliquid recusandae odio minus quisquam, corporis, sed consequuntur optio fugit eaque rerum, nihil mollitia. Sequi ad nulla facere."
           hasDivider={false}
           heading="Second subsection"
+          headingType="headline"
           isCentered={false}
           isMarkdown={false}
           isPureContent={false}
           required={false}
+          subHeadingType="heading"
         />
         <div>
           <Button
@@ -20557,6 +20597,7 @@ exports[`Storyshots UI Components/RoadmapHero basic usage 1`] = `
       isMarkdown={false}
       isPureContent={false}
       required={false}
+      subHeadingType="heading"
     />
   </div>
   <div>
@@ -20582,6 +20623,7 @@ exports[`Storyshots UI Components/RoadmapHero missing props (does component expl
       isMarkdown={false}
       isPureContent={false}
       required={false}
+      subHeadingType="heading"
     />
   </div>
   <div>
@@ -20609,6 +20651,7 @@ exports[`Storyshots UI Components/RoadmapHero with image url in props 1`] = `
       isMarkdown={false}
       isPureContent={false}
       required={false}
+      subHeadingType="heading"
     />
   </div>
   <div>
@@ -20631,6 +20674,7 @@ exports[`Storyshots UI Components/RoadmapLevel active state 1`] = `
   <Text
     content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consectetur, fuga suscipit rem voluptatibus sunt sapiente. Molestiae aliquam at libero repellat, asperiores, recusandae, praesentium ratione officia molestias nobis temporibus ipsam, repudiandae!"
     hasDivider={false}
+    headingType="headline"
     isCentered={false}
     isMarkdown={false}
     isPureContent={false}
@@ -20653,6 +20697,7 @@ exports[`Storyshots UI Components/RoadmapLevel basic usage 1`] = `
   <Text
     content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consectetur, fuga suscipit rem voluptatibus sunt sapiente. Molestiae aliquam at libero repellat, asperiores, recusandae, praesentium ratione officia molestias nobis temporibus ipsam, repudiandae!"
     hasDivider={false}
+    headingType="headline"
     isCentered={false}
     isMarkdown={false}
     isPureContent={false}
@@ -20675,6 +20720,7 @@ exports[`Storyshots UI Components/RoadmapLevel centered state with CTA button 1`
   <Text
     content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consectetur, fuga suscipit rem voluptatibus sunt sapiente. Molestiae aliquam at libero repellat, asperiores, recusandae, praesentium ratione officia molestias nobis temporibus ipsam, repudiandae!"
     hasDivider={false}
+    headingType="headline"
     isCentered={true}
     isMarkdown={false}
     isPureContent={false}
@@ -33745,10 +33791,12 @@ exports[`Storyshots UI Components/SettingsImportScreen default initial view 1`] 
     content="Import profiles to a List as \\"Accepted\\" via a newline separated list of emails."
     hasDivider={true}
     heading="Import"
+    headingType="headline"
     isCentered={true}
     isMarkdown={false}
     isPureContent={false}
     required={false}
+    subHeadingType="heading"
   />
   <ListSelector />
   <InputField
@@ -33794,10 +33842,12 @@ exports[`Storyshots UI Components/SettingsImportScreen imported view 1`] = `
     content="Import profiles to a List as \\"Accepted\\" via a newline separated list of emails."
     hasDivider={true}
     heading="Import"
+    headingType="headline"
     isCentered={true}
     isMarkdown={false}
     isPureContent={false}
     required={false}
+    subHeadingType="heading"
   />
   <div>
     <h3>
@@ -33865,10 +33915,12 @@ exports[`Storyshots UI Components/SettingsImportScreen imported view with server
     content="Import profiles to a List as \\"Accepted\\" via a newline separated list of emails."
     hasDivider={true}
     heading="Import"
+    headingType="headline"
     isCentered={true}
     isMarkdown={false}
     isPureContent={false}
     required={false}
+    subHeadingType="heading"
   />
   <ErrorBox
     errors={
@@ -33889,10 +33941,12 @@ exports[`Storyshots UI Components/SettingsImportScreen importing view 1`] = `
     content="Import profiles to a List as \\"Accepted\\" via a newline separated list of emails."
     hasDivider={true}
     heading="Import"
+    headingType="headline"
     isCentered={true}
     isMarkdown={false}
     isPureContent={false}
     required={false}
+    subHeadingType="heading"
   />
   <div>
     <h3>
@@ -33933,10 +33987,12 @@ exports[`Storyshots UI Components/SettingsImportScreen validated view containing
     content="Import profiles to a List as \\"Accepted\\" via a newline separated list of emails."
     hasDivider={true}
     heading="Import"
+    headingType="headline"
     isCentered={true}
     isMarkdown={false}
     isPureContent={false}
     required={false}
+    subHeadingType="heading"
   />
   <ListSelector
     selected={true}
@@ -34013,10 +34069,12 @@ exports[`Storyshots UI Components/SettingsImportScreen validated view containing
     content="Import profiles to a List as \\"Accepted\\" via a newline separated list of emails."
     hasDivider={true}
     heading="Import"
+    headingType="headline"
     isCentered={true}
     isMarkdown={false}
     isPureContent={false}
     required={false}
+    subHeadingType="heading"
   />
   <ListSelector
     selected={true}
@@ -36564,10 +36622,12 @@ exports[`Storyshots UI Components/Text/Demos content with HTML tags 1`] = `
     </div>
   }
   hasDivider={false}
+  headingType="headline"
   isCentered={false}
   isMarkdown={false}
   isPureContent={false}
   required={false}
+  subHeadingType="heading"
 />
 `;
 
@@ -36592,10 +36652,12 @@ Some things that [will help you stand out](http://google.com):
 
 This is _**custom content**_ btw"
   hasDivider={false}
+  headingType="headline"
   isCentered={false}
   isMarkdown={true}
   isPureContent={false}
   required={false}
+  subHeadingType="heading"
 />
 `;
 
@@ -36604,10 +36666,12 @@ exports[`Storyshots UI Components/Text/Demos heading 1`] = `
   content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
   hasDivider={false}
   heading="Your roadmap to X-Team"
+  headingType="headline"
   isCentered={false}
   isMarkdown={false}
   isPureContent={false}
   required={false}
+  subHeadingType="heading"
 />
 `;
 
@@ -36616,11 +36680,13 @@ exports[`Storyshots UI Components/Text/Demos heading and sub heading with divide
   content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
   hasDivider={true}
   heading="Your roadmap to X-Team"
+  headingType="headline"
   isCentered={false}
   isMarkdown={false}
   isPureContent={false}
   required={false}
   subHeading="Your roadmap to X-Team"
+  subHeadingType="heading"
 />
 `;
 
@@ -36629,10 +36695,12 @@ exports[`Storyshots UI Components/Text/Demos heading with center align 1`] = `
   content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
   hasDivider={false}
   heading="Your roadmap to X-Team"
+  headingType="headline"
   isCentered={true}
   isMarkdown={false}
   isPureContent={false}
   required={false}
+  subHeadingType="heading"
 />
 `;
 
@@ -36641,10 +36709,12 @@ exports[`Storyshots UI Components/Text/Demos heading with center align and divid
   content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
   hasDivider={true}
   heading="Your roadmap to X-Team"
+  headingType="headline"
   isCentered={true}
   isMarkdown={false}
   isPureContent={false}
   required={false}
+  subHeadingType="heading"
 />
 `;
 
@@ -36653,10 +36723,12 @@ exports[`Storyshots UI Components/Text/Demos heading with divider 1`] = `
   content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
   hasDivider={true}
   heading="Your roadmap to X-Team"
+  headingType="headline"
   isCentered={false}
   isMarkdown={false}
   isPureContent={false}
   required={false}
+  subHeadingType="heading"
 />
 `;
 
@@ -36664,10 +36736,12 @@ exports[`Storyshots UI Components/Text/Demos heading with divider and no content
 <Text
   hasDivider={true}
   heading="Your roadmap to X-Team"
+  headingType="headline"
   isCentered={false}
   isMarkdown={false}
   isPureContent={false}
   required={false}
+  subHeadingType="heading"
 />
 `;
 
@@ -36675,10 +36749,12 @@ exports[`Storyshots UI Components/Text/Demos pure content with no wrappers aroun
 <Text
   content="Just a sample text"
   hasDivider={false}
+  headingType="headline"
   isCentered={false}
   isMarkdown={false}
   isPureContent={true}
   required={false}
+  subHeadingType="heading"
 />
 `;
 
@@ -36686,10 +36762,12 @@ exports[`Storyshots UI Components/Text/Demos pure content with no wrappers aroun
 <Text
   content="Just a required text"
   hasDivider={false}
+  headingType="headline"
   isCentered={false}
   isMarkdown={false}
   isPureContent={true}
   required={true}
+  subHeadingType="heading"
 />
 `;
 
@@ -36697,10 +36775,12 @@ exports[`Storyshots UI Components/Text/Demos required 1`] = `
 <Text
   content="Just a required text"
   hasDivider={false}
+  headingType="headline"
   isCentered={false}
   isMarkdown={false}
   isPureContent={false}
   required={true}
+  subHeadingType="heading"
 />
 `;
 
@@ -36708,11 +36788,13 @@ exports[`Storyshots UI Components/Text/Demos sub Heading with center align 1`] =
 <Text
   content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
   hasDivider={false}
+  headingType="headline"
   isCentered={true}
   isMarkdown={false}
   isPureContent={false}
   required={false}
   subHeading="Your roadmap to X-Team"
+  subHeadingType="heading"
 />
 `;
 
@@ -36720,11 +36802,13 @@ exports[`Storyshots UI Components/Text/Demos sub Heading with divider 1`] = `
 <Text
   content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
   hasDivider={true}
+  headingType="headline"
   isCentered={false}
   isMarkdown={false}
   isPureContent={false}
   required={false}
   subHeading="Your roadmap to X-Team"
+  subHeadingType="heading"
 />
 `;
 
@@ -36732,12 +36816,14 @@ exports[`Storyshots UI Components/Text/Demos sub Heading with level 1`] = `
 <Text
   content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
   hasDivider={false}
+  headingType="headline"
   isCentered={false}
   isMarkdown={false}
   isPureContent={false}
   level="Level 7"
   required={false}
   subHeading="Your roadmap to X-Team"
+  subHeadingType="heading"
 />
 `;
 
@@ -36745,12 +36831,14 @@ exports[`Storyshots UI Components/Text/Demos sub Heading with level and center a
 <Text
   content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
   hasDivider={false}
+  headingType="headline"
   isCentered={true}
   isMarkdown={false}
   isPureContent={false}
   level="Level 7"
   required={false}
   subHeading="Your roadmap to X-Team"
+  subHeadingType="heading"
 />
 `;
 
@@ -36758,11 +36846,13 @@ exports[`Storyshots UI Components/Text/Demos sub heading 1`] = `
 <Text
   content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
   hasDivider={false}
+  headingType="headline"
   isCentered={false}
   isMarkdown={false}
   isPureContent={false}
   required={false}
   subHeading="Your roadmap to X-Team"
+  subHeadingType="heading"
 />
 `;
 
@@ -36770,10 +36860,12 @@ exports[`Storyshots UI Components/Text/Demos without Heading and Sub Heading wit
 <Text
   content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
   hasDivider={true}
+  headingType="headline"
   isCentered={false}
   isMarkdown={false}
   isPureContent={false}
   required={false}
+  subHeadingType="heading"
 />
 `;
 
@@ -36781,10 +36873,12 @@ exports[`Storyshots UI Components/Text/Demos without Heading and Sub Heading wit
 <Text
   content="Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you."
   hasDivider={true}
+  headingType="headline"
   isCentered={true}
   isMarkdown={false}
   isPureContent={false}
   required={false}
+  subHeadingType="heading"
 />
 `;
 
@@ -38370,6 +38464,21 @@ exports[`Storyshots UI Components/Typography typography sets for development ref
       className="AutoUI_ui_Typography-41"
     >
       formText
+    </div>
+  </div>
+  <div
+    className="AutoUI_ui_Typography-20 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40"
+    key="9"
+  >
+    <span
+      className="AutoUI_ui_Typography-35 AutoUI_typo-192 AutoUI_typo-53 AutoUI_typo-40"
+    >
+      The quick brown fox jumps over the lazy dog
+    </span>
+    <div
+      className="AutoUI_ui_Typography-41"
+    >
+      link
     </div>
   </div>
 </section>

--- a/src/components/ui/Text.js
+++ b/src/components/ui/Text.js
@@ -112,8 +112,7 @@ class Text extends PureComponent<Props> {
     required: false
   }
 
-  get htmlContent (): ?ContentType {
-    const { content } = this.props
+  htmlContent = (content: ?ContentType): ?ContentType => {
     try {
       return markdownCompiler(content)
     } catch (err) {
@@ -136,7 +135,7 @@ class Text extends PureComponent<Props> {
       required
     } = this.props
     const requiredProps = required ? { className: contentRequired } : {}
-    const contentRender = isMarkdown ? this.htmlContent : content
+    const contentRender = isMarkdown ? this.htmlContent(content) : content
 
     if (isPureContent) {
       return PureContent(requiredProps, contentRender)

--- a/src/components/ui/Text.js
+++ b/src/components/ui/Text.js
@@ -49,17 +49,7 @@ const Content = elem.div(cmz(
   `
     & {
       margin: 15px 0
-
       box-sizing: content-box
-      text-rendering: optimizeLegibility
-      -webkit-font-smoothing: antialiased
-      -moz-osx-font-smoothing: grayscale
-
-      font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif
-      font-weight: 300
-      font-size: 20px
-      color: rgb(52, 50, 59)
-      line-height: 30px
     }
 
     & h1,
@@ -67,7 +57,7 @@ const Content = elem.div(cmz(
       font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif
       font-weight: 800
       text-transform: uppercase
-      color: rgb(52, 50, 59)
+      color: ${theme.typoHeading}
     }
 
     & h1 {
@@ -80,7 +70,6 @@ const Content = elem.div(cmz(
     & h2 {
       font-size: 22px
       margin: 0 0 .5rem
-      padding: 37px 0 0 0
       letter-spacing: -.61px
       line-height: 30px
     }
@@ -123,7 +112,8 @@ class Text extends PureComponent<Props> {
     required: false
   }
 
-  htmlContent = (content?: ContentType) => {
+  get htmlContent(): ?ContentType {
+    const { content } = this.props
     try {
       return markdownCompiler(content)
     } catch (err) {
@@ -146,7 +136,7 @@ class Text extends PureComponent<Props> {
       required
     } = this.props
     const requiredProps = required ? { className: contentRequired } : {}
-    const contentRender = isMarkdown ? this.htmlContent(content) : content
+    const contentRender = isMarkdown ? this.htmlContent : content
 
     if (isPureContent) {
       return PureContent(requiredProps, contentRender)

--- a/src/components/ui/Text.js
+++ b/src/components/ui/Text.js
@@ -47,41 +47,8 @@ const Divider = elem.span(cmz(typo.divider))
 const Content = elem.div(cmz(
   typo.baseText,
   `
-    & {
-      margin: 15px 0
-      box-sizing: content-box
-    }
-
-    & h1,
-    & h2 {
-      font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif
-      font-weight: 800
-      text-transform: uppercase
-      color: ${theme.typoHeading}
-    }
-
-    & h1 {
-      font-size: 36px
-      margin: 0 0 16px
-      letter-spacing: -1px
-      line-height: 49px
-    }
-
-    & h2 {
-      font-size: 22px
-      margin: 0 0 .5rem
-      letter-spacing: -.61px
-      line-height: 30px
-    }
-
-    & a {
-      color: ${theme.typoAnchor}
-      text-decoration: none
-    }
-
-    & a:hover {
-      color: ${theme.typoAnchorHover}
-    }
+    margin: 15px 0
+    box-sizing: content-box
   `
 ))
 
@@ -109,12 +76,33 @@ class Text extends PureComponent<Props> {
     isCentered: false,
     hasDivider: false,
     isPureContent: false,
-    required: false
+    required: false,
+    headingType: 'headline',
+    subHeadingType: 'heading'
   }
 
-  htmlContent = (content: ?ContentType): ?ContentType => {
+  htmlContent = (): ?ContentType => {
+    const { content, headingType, subHeadingType } = this.props
     try {
-      return markdownCompiler(content)
+      return markdownCompiler(content, {
+        overrides: {
+          h1: {
+            props: {
+              className: typo[headingType]
+            }
+          },
+          h2: {
+            props: {
+              className: typo[subHeadingType]
+            }
+          },
+          a: {
+            props: {
+              className: typo.link
+            }
+          }
+        }
+      })
     } catch (err) {
       return content
     }
@@ -124,8 +112,8 @@ class Text extends PureComponent<Props> {
     const {
       heading,
       subHeading,
-      headingType = 'headline',
-      subHeadingType = 'heading',
+      headingType,
+      subHeadingType,
       level,
       content,
       isMarkdown,
@@ -135,7 +123,7 @@ class Text extends PureComponent<Props> {
       required
     } = this.props
     const requiredProps = required ? { className: contentRequired } : {}
-    const contentRender = isMarkdown ? this.htmlContent(content) : content
+    const contentRender = isMarkdown ? this.htmlContent() : content
 
     if (isPureContent) {
       return PureContent(requiredProps, contentRender)

--- a/src/components/ui/Text.js
+++ b/src/components/ui/Text.js
@@ -84,6 +84,15 @@ const Content = elem.div(cmz(
       letter-spacing: -.61px
       line-height: 30px
     }
+
+    & a {
+      color: ${theme.typoAnchor}
+      text-decoration: none
+    }
+
+    & a:hover {
+      color: ${theme.typoAnchorHover}
+    }
   `
 ))
 

--- a/src/components/ui/Text.js
+++ b/src/components/ui/Text.js
@@ -112,7 +112,7 @@ class Text extends PureComponent<Props> {
     required: false
   }
 
-  get htmlContent(): ?ContentType {
+  get htmlContent (): ?ContentType {
     const { content } = this.props
     try {
       return markdownCompiler(content)

--- a/src/components/ui/Text.stories.js
+++ b/src/components/ui/Text.stories.js
@@ -8,8 +8,8 @@ import Text from './Text'
 const StoryText = ({
   heading,
   subHeading,
-  headingType,
-  subHeadingType,
+  headingType = 'headline',
+  subHeadingType = 'heading',
   content,
   isMarkdown,
   isCentered,

--- a/src/components/ui/Text.stories.js
+++ b/src/components/ui/Text.stories.js
@@ -1,72 +1,169 @@
-// @flow
-
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { text, boolean, select, withKnobsOptions } from '@storybook/addon-knobs'
+import faker from 'faker'
 
 import Text from './Text'
 
+const StoryText = ({
+  heading,
+  subHeading,
+  headingType,
+  subHeadingType,
+  content,
+  isMarkdown,
+  isCentered,
+  hasDivider,
+  isPureContent,
+  required,
+  level
+}) => (
+  <Text
+    heading={text('heading', heading)}
+    headingType={select('headingType', typos, headingType)}
+    subHeading={text('subHeading', subHeading)}
+    subHeadingType={select('subHeadingType', typos, subHeadingType)}
+    level={text('level', level)}
+    content={text('content', content)}
+    isMarkdown={boolean('isMarkdown', isMarkdown)}
+    isCentered={boolean('isCentered', isCentered)}
+    hasDivider={boolean('hasDivider', hasDivider)}
+    required={boolean('required', required)}
+    isPureContent={boolean('isPureContent', isPureContent)}
+  />
+)
+
+const typos = {
+  badgeHeading: 'badgeHeading',
+  baseText: 'baseText',
+  divider: 'divider',
+  formText: 'formText',
+  heading: 'heading',
+  headline: 'headline',
+  labelText: 'labelText',
+  mainHeading: 'mainHeading',
+  sectionHeading: 'sectionHeading',
+  subheading: 'subheading',
+}
+
+const typosLenght = Object.keys(typos)
+const typosHeadingTypeIndex = faker.random.number(typosLenght.length - 1)
+const typosSubHeadingTypeIndex = faker.random.number(typosLenght.length - 1)
+
+const fakeHeading = faker.lorem.sentence()
+const fakeHeadingType = typosLenght[typosHeadingTypeIndex]
+const fakeSubHeading = faker.lorem.sentence()
+const fakeSubHeadingType = typosLenght[typosSubHeadingTypeIndex]
+const fakeLevel = faker.lorem.sentence()
+const fakeContent = faker.lorem.paragraphs()
+const fakeIsCentered = faker.random.boolean()
+const fakeHasDivider = faker.random.boolean()
+const fakeRequired = faker.random.boolean()
+const fakeIsPureContent = false
+
 storiesOf('UI Components/Text', module)
-  .add('empty text example ', () => <Text />)
+  .add('showcase (use knobs)', () => (
+    <StoryText
+      heading={fakeHeading}
+      headingType={fakeHeadingType}
+      subHeading={fakeSubHeading}
+      subHeadingType={fakeSubHeadingType}
+      level={fakeLevel}
+      content={fakeContent}
+      isCentered={fakeIsCentered}
+      hasDivider={fakeHasDivider}
+      required={fakeRequired}
+      isPureContent={fakeIsPureContent}
+    />
+  ), {
+    notes: {
+      markdown: `
+# About the props
+
+## content
+
+This prop allows string and JSX.
+
+## headingType and subHeading
+
+The examples provided in knobs comes from \`typo\` object:
+
+\`import typo from '../../styles/typo'\`
+
+See here: [Typography](http://localhost:9001/?selectedKind=UI%20Components%2FTypography)
+      `
+    }
+  })
+
+storiesOf('UI Components/Text/Demos', module)
   .add('heading', () => (
-    <Text
+    <StoryText
       heading='Your roadmap to X-Team'
       content='Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.'
     />
   ))
   .add('heading with divider', () => (
-    <Text
+    <StoryText
       heading='Your roadmap to X-Team'
       content='Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.'
       hasDivider
     />
   ))
   .add('heading with divider and no content', () => (
-    <Text heading='Your roadmap to X-Team' hasDivider />
+    <StoryText heading='Your roadmap to X-Team' hasDivider />
   ))
   .add('heading with center align', () => (
-    <Text
+    <StoryText
       heading='Your roadmap to X-Team'
       content='Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.'
       isCentered
     />
   ))
   .add('heading with center align and divider', () => (
-    <Text
+    <StoryText
       heading='Your roadmap to X-Team'
       content='Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.'
       isCentered
       hasDivider
     />
   ))
+  .add('heading and sub heading with divider', () => (
+    <StoryText
+      heading='Your roadmap to X-Team'
+      subHeading='Your roadmap to X-Team'
+      content='Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.'
+      hasDivider
+    />
+  ))
   .add('sub heading', () => (
-    <Text
+    <StoryText
       subHeading='Your roadmap to X-Team'
       content='Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.'
     />
   ))
   .add('sub Heading with center align', () => (
-    <Text
+    <StoryText
       subHeading='Your roadmap to X-Team'
       content='Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.'
       isCentered
     />
   ))
   .add('sub Heading with divider', () => (
-    <Text
+    <StoryText
       subHeading='Your roadmap to X-Team'
       content='Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.'
       hasDivider
     />
   ))
   .add('sub Heading with level', () => (
-    <Text
+    <StoryText
       subHeading='Your roadmap to X-Team'
       level='Level 7'
       content='Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.'
     />
   ))
   .add('sub Heading with level and center align', () => (
-    <Text
+    <StoryText
       subHeading='Your roadmap to X-Team'
       level='Level 7'
       content='Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.'
@@ -74,27 +171,27 @@ storiesOf('UI Components/Text', module)
     />
   ))
   .add('without Heading and Sub Heading with divider', () => (
-    <Text
+    <StoryText
       content='Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.'
       hasDivider
     />
   ))
   .add('without Heading and Sub Heading with isCentered align', () => (
-    <Text
+    <StoryText
       content='Many developers who came before you started right here and went on to do some of the best work of their career. That same opportunity begins now for you.'
       isCentered
       hasDivider
     />
   ))
   .add('pure content with no wrappers around', () => (
-    <Text content='Just a sample text' isPureContent />
+    <StoryText content='Just a sample text' isPureContent />
   ))
-  .add('required', () => <Text content='Just a required text' required />)
+  .add('required', () => <StoryText content='Just a required text' required />)
   .add('pure content with no wrappers around and Required', () => (
-    <Text content='Just a required text' isPureContent required />
+    <StoryText content='Just a required text' isPureContent required />
   ))
   .add('content with HTML tags', () => (
-    <Text content={(
+    <StoryText content={(
       <div>
         <h1>H1</h1>
         <h2>H2</h2>
@@ -115,4 +212,31 @@ storiesOf('UI Components/Text', module)
         <p><strong>Paragraph:</strong> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas scelerisque vestibulum sem id cursus. Fusce nec consequat erat. Praesent convallis aliquet augue, vel lacinia urna pretium eu. Morbi accumsan neque sit amet feugiat molestie. Aliquam erat volutpat. Cras quis dapibus risus. Proin luctus hendrerit semper. Donec finibus hendrerit ante at egestas.</p>
       </div>
     )} />
+  ))
+  .add('content with Markdown', () => (
+    <StoryText isMarkdown content={`# Time to show off.
+
+It\'s great getting to know you! After you sign up, X-Teamers from our community review profiles and send invitations to those they see standing out.
+
+### Lorem Ipsum
+
+Due to high demand, we send out a limited number of invites each month, meaning we can't guarantee you'll hear from us about an interview.
+
+Some things that will help you stand out:
+
+- Experience working on large scale projects with a significant user base.
+- Strong written and spoken English.
+- A LinkedIn profile that details the projects you've worked on.
+- Availability for long-term fulltime contracts (the average contract duration is 10 months).
+
+This is _**custom content**_ btw`} />
+  ), {
+    knobs: {
+      escapeHTML: false
+    }
+  })
+
+storiesOf('UI Components/Text/Debug', module)
+  .add('missing props (does component explode?)', () => (
+    <Text />
   ))

--- a/src/components/ui/Text.stories.js
+++ b/src/components/ui/Text.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { text, boolean, select, withKnobsOptions } from '@storybook/addon-knobs'
+import { text, boolean, select } from '@storybook/addon-knobs'
 import faker from 'faker'
 
 import Text from './Text'

--- a/src/components/ui/Text.stories.js
+++ b/src/components/ui/Text.stories.js
@@ -232,6 +232,7 @@ Some things that will help you stand out:
 This is _**custom content**_ btw`} />
   ), {
     knobs: {
+      timestamps: true,
       escapeHTML: false
     }
   })

--- a/src/components/ui/Text.stories.js
+++ b/src/components/ui/Text.stories.js
@@ -218,11 +218,13 @@ storiesOf('UI Components/Text/Demos', module)
 
 It\'s great getting to know you! After you sign up, X-Teamers from our community review profiles and send invitations to those they see standing out.
 
-### Lorem Ipsum
+## Lorem Ipsum
 
 Due to high demand, we send out a limited number of invites each month, meaning we can't guarantee you'll hear from us about an interview.
 
-Some things that will help you stand out:
+### Sit dolor amet
+
+Some things that [will help you stand out](http://google.com):
 
 - Experience working on large scale projects with a significant user base.
 - Strong written and spoken English.

--- a/src/components/ui/Text.stories.js
+++ b/src/components/ui/Text.stories.js
@@ -43,7 +43,7 @@ const typos = {
   labelText: 'labelText',
   mainHeading: 'mainHeading',
   sectionHeading: 'sectionHeading',
-  subheading: 'subheading',
+  subheading: 'subheading'
 }
 
 const typosLenght = Object.keys(typos)
@@ -216,7 +216,7 @@ storiesOf('UI Components/Text/Demos', module)
   .add('content with Markdown', () => (
     <StoryText isMarkdown content={`# Time to show off.
 
-It\'s great getting to know you! After you sign up, X-Teamers from our community review profiles and send invitations to those they see standing out.
+It's great getting to know you! After you sign up, X-Teamers from our community review profiles and send invitations to those they see standing out.
 
 ## Lorem Ipsum
 

--- a/src/components/ui/Typography.js
+++ b/src/components/ui/Typography.js
@@ -50,7 +50,6 @@ class Typography extends PureComponent<Props> {
     const typoBlocks = []
 
     Object.keys(typo)
-      .filter(key => key !== 'divider')
       .forEach((key, i) => {
         typoBlocks.push(
           Item(

--- a/src/components/ui/Typography.js
+++ b/src/components/ui/Typography.js
@@ -50,6 +50,7 @@ class Typography extends PureComponent<Props> {
     const typoBlocks = []
 
     Object.keys(typo)
+      .filter(key => key !== 'divider')
       .forEach((key, i) => {
         typoBlocks.push(
           Item(

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -24,6 +24,7 @@ const palette = {
   haiti: '#130E2E',
   fern: '#5CB85C',
   radicalRed: '#F63954',
+  redRibbon: '#F20B2C',
   alto: '#D8D8D8',
   nobel: '#B3B3B3',
   tuna: '#34323B',
@@ -62,6 +63,8 @@ export default wrap({
 
   typoHeading: palette.tuna,
   typoSubheading: palette.radicalRed,
+  typoAnchor: palette.radicalRed,
+  typoAnchorHover: palette.redRibbon,
   typoParagraph: palette.tuna,
   typoParagraphOnDarkBackground: palette.frenchGrayDarker,
   typoHighlight: palette.haiti,

--- a/src/styles/typo.js
+++ b/src/styles/typo.js
@@ -188,6 +188,22 @@ export default {
     `
   ),
 
+  // default links
+  link: cmz(
+    textRendering,
+    typeface.text,
+    `
+      & {
+        color: ${theme.typoAnchor}
+        text-decoration: none
+      }
+
+      &:hover {
+        color: ${theme.typoAnchorHover}
+      }
+    `
+  ),
+
   // text divider
   divider: cmz(`
     & {


### PR DESCRIPTION
**Release Type:** *non-braking changes*

Fixes https://x-team-internal.atlassian.net/browse/XP-3086

## Description

Adapt `Text` to render Markdown content and apply basic typography styles.

## Checklist

- [x] set yourself as an assignee
- [x] set appropriate labels for a PR (`In Review` or `In Progress` depending on its status)
- [x] move respective JIRA issue to the `IN REVIEW` column
- [x] fill out `Is a breaking change` and `Release Type Reason` (if required) fields for the ticket. This is accessible when editing an issue in JIRA <br /><img src="https://user-images.githubusercontent.com/579331/55951136-33125a00-5c5f-11e9-9d6a-1c159fc2c925.png" width="240" />
- [x] make sure your code lints (`npm run lint`)
- [x] Flow typechecks passed (`npm run flow`)
- [x] Snapshots tests passed (`npm run jest`)
- [x] check cleanup tasks (https://github.com/x-team/xp/labels/cleanup) and take a suitable small one (if exists) in a related area of the current changes
- [x] component's documentation (`.stories.js` file) is changed or added accordingly to reflect any new or updated use cases or variants usage
- [x] if you've fixed a bug, make sure to also include a new story that will expose declarations with problematic data that caused the bug in the first place, so that we can assure that no regressions will pop up on future interactions
- [x] if any snapshots have been changed, verify that component still works and looks as expected and update the changed snapshot
- [x] **manually tested the app** by running it in several different browsers (Firefox, Chrome, Opera, Safari, MS IE/Edge, etc.) and checked nothing is broken and operates as expected!

## Related PRs

branch | PR
------ | ------
`XP-3086-render-typography-with-text-on-strapisection-component` | [XP REG](https://github.com/x-team/xp-registration/pull/53)

## Steps to Test or Reproduce

### XP UI

1. Make sure to run `npm install` first
1. Run `npm start`
1. Go to http://localhost:9001/?selectedKind=UI%20Components%2FText%2FDemos&selectedStory=content%20with%20Markdown
1. Observe that the Markdown is rendered and styled as expected

### XP

1. Copy xp-ui lib files to xp node modules (e.g. in `xp` directory run `cp -R ../xp-ui/lib/ node_modules/xp-ui/lib/ && npm run watch`)
1. Navigate in the app and observe that Text usages didn't have any regression
1. Compare applicant-facing screens presentation with the same ones in xp-registration

### XP Registration

1. Make sure to follow instructions from this PR https://github.com/x-team/xp-registration/pull/53
1. Copy xp-ui lib files to xp-registration node modules
1. Navigate in the app and compare the presentation of xp's applicant-facing screens

## Impacted Areas in Application

- Text component
- Theme colours palette

## Screenshots

<img width="1012" alt="Screen Shot 2019-05-28 at 17 32 16" src="https://user-images.githubusercontent.com/131859/58510181-96543f00-816e-11e9-8b14-760793974852.png">

![2019-05-28 21 21 18](https://user-images.githubusercontent.com/131859/58520549-b98ee680-818e-11e9-83c6-7d3401cfa73b.gif)
