### PR TITLE
Add data-testid attribute needed for the E2E tests in the Search Page for the switching lists cases

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -22089,6 +22089,88 @@ exports[`Storyshots UI Components/HeaderBar basic usage 1`] = `
 </div>
 `;
 
+exports[`Storyshots UI Components/HeadingWithQuickSearch fully-controlled sidebar heading 1`] = `
+<Heading>
+  <HeadingWithQuickSearch
+    headingAction={[Function]}
+    isQuickSearching={false}
+    leftIcon="filters"
+    onQuickSearchChangeValue={[Function]}
+    onToggleQuickSearch={[Function]}
+    quickSearchValue=""
+    text="Filters"
+  />
+</Heading>
+`;
+
+exports[`Storyshots UI Components/HeadingWithQuickSearch self-controlled sidebar heading 1`] = `
+<div
+  style={
+    Object {
+      "backgroundColor": "rgb(249, 250, 251)",
+      "border": "1px solid rgb(233, 237, 238)",
+      "height": "58px",
+      "width": "400px",
+    }
+  }
+>
+  <HeadingWithQuickSearch
+    headingAction={[Function]}
+    leftIcon="filters"
+    onQuickSearchSubmit={[Function]}
+    text="Filters"
+  />
+</div>
+`;
+
+exports[`Storyshots UI Components/HeadingWithQuickSearch/Debug missing props (does component explode?) 1`] = `
+<div
+  className="AutoUI_ui_HeadingWithQuickSearch-18 AutoUI_typo-22"
+>
+  <QuickSearchButton
+    onClick={[Function]}
+  />
+</div>
+`;
+
+exports[`Storyshots UI Components/HeadingWithQuickSearch/Debug with action handler 1`] = `
+<div
+  style={
+    Object {
+      "backgroundColor": "rgb(249, 250, 251)",
+      "border": "1px solid rgb(233, 237, 238)",
+      "height": "58px",
+      "width": "400px",
+    }
+  }
+>
+  <HeadingWithQuickSearch
+    headingAction={[Function]}
+    leftIcon="arrowleft"
+    text="Click this arrow"
+  />
+</div>
+`;
+
+exports[`Storyshots UI Components/HeadingWithQuickSearch/Debug without wrapper 1`] = `
+<div
+  className="AutoUI_ui_HeadingWithQuickSearch-18 AutoUI_typo-22"
+>
+  <div
+    className="AutoUI_ui_HeadingWithQuickSearch-30"
+  >
+    <SvgIcon
+      color="frenchGrayDarker"
+      icon="arrowleft"
+    />
+  </div>
+  Click this arrow
+  <QuickSearchButton
+    onClick={[Function]}
+  />
+</div>
+`;
+
 exports[`Storyshots UI Components/HorizontalRuler basic usage 1`] = `
 <hr
   className="AutoUI_ui_HorizontalRuler-12"
@@ -25463,6 +25545,34 @@ exports[`Storyshots UI Components/ProfileHeaderLinks missing props (does compone
 <ul
   className="AutoUI_ui_ProfileHeaderLinks-12 AutoUI_ui_ProfileHeaderLinks-22"
 />
+`;
+
+exports[`Storyshots UI Components/QuickSearchButton basic usage 1`] = `
+<div
+  style={
+    Object {
+      "padding": "10px 0",
+      "width": "64px",
+    }
+  }
+>
+  <QuickSearchButton
+    onClick={[Function]}
+  />
+</div>
+`;
+
+exports[`Storyshots UI Components/QuickSearchButton/Debug missing props (does component explode?) 1`] = `
+<div
+  className="AutoUI_ui_QuickSearchButton-15"
+  onClick={[Function]}
+>
+  <SvgIcon
+    color="grayscarpaflow"
+    hover="default"
+    icon="magnifier"
+  />
+</div>
 `;
 
 exports[`Storyshots UI Components/ResultCount basic usage 1`] = `
@@ -43202,7 +43312,7 @@ exports[`Storyshots UI Components/TwoColumnsLayout/Debug composed in AdminScreen
         />
       }
       sidebarHeading="A link in the sidebar heading"
-      sidebarHeadingLink={[Function]}
+      sidebarHeadingAction={[Function]}
       sidebarIcon="arrowleft"
       sidebarWidth={425}
     />
@@ -43306,6 +43416,54 @@ exports[`Storyshots UI Components/TwoColumnsLayout/Debug standalone with very lo
 </div>
 `;
 
+exports[`Storyshots UI Components/TwoColumnsLayout/Debug with composed headings in AdminScreen 1`] = `
+<div
+  style={
+    Object {
+      "height": "100vh",
+    }
+  }
+>
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "
+      html, body { margin: 0; height: 100%; }
+    ",
+      }
+    }
+  />
+  <StoryAdminScreen>
+    <StoryTwoColumnsLayout
+      contentHeading={
+        <div
+          style={
+            Object {
+              "backgroundColor": "black",
+              "color": "white",
+            }
+          }
+        >
+          bump
+        </div>
+      }
+      sidebarHeading={
+        <div
+          style={
+            Object {
+              "backgroundColor": "black",
+              "color": "white",
+            }
+          }
+        >
+          bump
+        </div>
+      }
+    />
+  </StoryAdminScreen>
+</div>
+`;
+
 exports[`Storyshots UI Components/TwoColumnsLayout/Debug with short content and composed in AdminScreen 1`] = `
 <div
   style={
@@ -43363,7 +43521,7 @@ exports[`Storyshots UI Components/TwoColumnsLayout/Use cases composed in AdminSc
 </div>
 `;
 
-exports[`Storyshots UI Components/TwoColumnsLayout/Use cases composed in AdminScreen with Filters 1`] = `
+exports[`Storyshots UI Components/TwoColumnsLayout/Use cases composed in AdminScreen with Filters and sidebarHeading element 1`] = `
 <div
   style={
     Object {
@@ -43383,6 +43541,12 @@ exports[`Storyshots UI Components/TwoColumnsLayout/Use cases composed in AdminSc
   <StoryAdminScreen>
     <StoryTwoColumnsLayout
       sidebar={<StoryFilters />}
+      sidebarHeading={
+        <HeadingWithQuickSearch
+          leftIcon="filters"
+          text="Filters"
+        />
+      }
     />
   </StoryAdminScreen>
 </div>

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -15805,9 +15805,11 @@ exports[`Storyshots UI Components/DataGrid/Debug missing props (does component e
 exports[`Storyshots UI Components/Dropdown SelectBox example 1`] = `
 <div
   className="AutoUI_ui_Dropdown-17 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 "
+  data-testid="xpui-dropdown"
 >
   <div
     className="AutoUI_ui_Dropdown-24 AutoUI_ui_Dropdown-44"
+    data-testid="xpui-dropdown__button"
     onClick={[Function]}
   >
     <SvgIcon
@@ -15816,6 +15818,7 @@ exports[`Storyshots UI Components/Dropdown SelectBox example 1`] = `
     />
     <span
       className="AutoUI_ui_Dropdown-40"
+      data-testid="xpui-dropdown__button__label"
     >
       This is a Dropdown
     </span>
@@ -15830,6 +15833,7 @@ exports[`Storyshots UI Components/Dropdown SelectBox example 1`] = `
   </div>
   <div
     className="AutoUI_ui_Dropdown-50     "
+    data-testid="xpui-dropdown__children"
   >
     <SelectBox
       areItemsToggleable={true}
@@ -15885,13 +15889,16 @@ exports[`Storyshots UI Components/Dropdown SelectBox example 1`] = `
 exports[`Storyshots UI Components/Dropdown SelectBox example using radio buttons 1`] = `
 <div
   className="AutoUI_ui_Dropdown-17 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 "
+  data-testid="xpui-dropdown"
 >
   <div
     className="AutoUI_ui_Dropdown-24 AutoUI_ui_Dropdown-44"
+    data-testid="xpui-dropdown__button"
     onClick={[Function]}
   >
     <span
       className="AutoUI_ui_Dropdown-40"
+      data-testid="xpui-dropdown__button__label"
     >
       registered
     </span>
@@ -15906,6 +15913,7 @@ exports[`Storyshots UI Components/Dropdown SelectBox example using radio buttons
   </div>
   <div
     className="AutoUI_ui_Dropdown-50     "
+    data-testid="xpui-dropdown__children"
   >
     <SelectBox
       areItemsToggleable={true}
@@ -15961,13 +15969,16 @@ exports[`Storyshots UI Components/Dropdown SelectBox example using radio buttons
 exports[`Storyshots UI Components/Dropdown close Dropdown from children 1`] = `
 <div
   className="AutoUI_ui_Dropdown-17 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 "
+  data-testid="xpui-dropdown"
 >
   <div
     className="AutoUI_ui_Dropdown-24 "
+    data-testid="xpui-dropdown__button"
     onClick={[Function]}
   >
     <span
       className="AutoUI_ui_Dropdown-40"
+      data-testid="xpui-dropdown__button__label"
     >
       <h1>
         Click to open!
@@ -15976,9 +15987,11 @@ exports[`Storyshots UI Components/Dropdown close Dropdown from children 1`] = `
   </div>
   <div
     className="AutoUI_ui_Dropdown-50    AutoUI_ui_Dropdown-111 "
+    data-testid="xpui-dropdown__children"
   >
     <div
       className="AutoUI_ui_Dropdown-71 "
+      data-testid="xpui-dropdown__children__tooltip"
     >
       <CloseButton
         closeDropdown={[Function]}
@@ -15992,9 +16005,11 @@ exports[`Storyshots UI Components/Dropdown close Dropdown from children 1`] = `
 exports[`Storyshots UI Components/Dropdown icon only button 1`] = `
 <div
   className="AutoUI_ui_Dropdown-17 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 "
+  data-testid="xpui-dropdown"
 >
   <div
     className="AutoUI_ui_Dropdown-24 AutoUI_ui_Dropdown-44"
+    data-testid="xpui-dropdown__button"
     onClick={[Function]}
   >
     <SvgIcon
@@ -16004,6 +16019,7 @@ exports[`Storyshots UI Components/Dropdown icon only button 1`] = `
   </div>
   <div
     className="AutoUI_ui_Dropdown-50     "
+    data-testid="xpui-dropdown__children"
   >
     <div
       key=".0"
@@ -16089,9 +16105,11 @@ exports[`Storyshots UI Components/Dropdown label and indicator positioned on the
 exports[`Storyshots UI Components/Dropdown labeled button 1`] = `
 <div
   className="AutoUI_ui_Dropdown-17 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 "
+  data-testid="xpui-dropdown"
 >
   <div
     className="AutoUI_ui_Dropdown-24 "
+    data-testid="xpui-dropdown__button"
     onClick={[Function]}
   >
     <SvgIcon
@@ -16100,6 +16118,7 @@ exports[`Storyshots UI Components/Dropdown labeled button 1`] = `
     />
     <span
       className="AutoUI_ui_Dropdown-40"
+      data-testid="xpui-dropdown__button__label"
     >
       Add to List
     </span>
@@ -16114,6 +16133,7 @@ exports[`Storyshots UI Components/Dropdown labeled button 1`] = `
   </div>
   <div
     className="AutoUI_ui_Dropdown-50     "
+    data-testid="xpui-dropdown__children"
   >
     <div
       key=".0"
@@ -16174,13 +16194,16 @@ exports[`Storyshots UI Components/Dropdown missing props (does component explode
 exports[`Storyshots UI Components/Dropdown tooltip display 1`] = `
 <div
   className="AutoUI_ui_Dropdown-17 AutoUI_typo-170 AutoUI_typo-53 AutoUI_typo-40 "
+  data-testid="xpui-dropdown"
 >
   <div
     className="AutoUI_ui_Dropdown-24 "
+    data-testid="xpui-dropdown__button"
     onClick={[Function]}
   >
     <span
       className="AutoUI_ui_Dropdown-40"
+      data-testid="xpui-dropdown__button__label"
     >
       <Button
         block={false}
@@ -16208,9 +16231,11 @@ exports[`Storyshots UI Components/Dropdown tooltip display 1`] = `
   </div>
   <div
     className="AutoUI_ui_Dropdown-50    AutoUI_ui_Dropdown-111 "
+    data-testid="xpui-dropdown__children"
   >
     <div
       className="AutoUI_ui_Dropdown-71 "
+      data-testid="xpui-dropdown__children__tooltip"
     >
       Anything here
     </div>
@@ -22824,12 +22849,15 @@ exports[`Storyshots UI Components/MetaGroup standalone composed with children 1`
 exports[`Storyshots UI Components/MetaGroup/Debug missing props (does component explode?) 1`] = `
 <div
   className="AutoUI_ui_MetaGroup-10"
+  data-testid="xpui-metaGroup__layout"
 >
   <div
     className="AutoUI_ui_MetaGroup-15"
+    data-testid="xpui-metaGroup__mainBodyColumn"
   />
   <div
     className="AutoUI_ui_MetaGroup-21"
+    data-testid="xpui-metaGroup__secondaryColumns"
   />
 </div>
 `;
@@ -25578,6 +25606,7 @@ exports[`Storyshots UI Components/QuickSearchButton/Debug missing props (does co
 exports[`Storyshots UI Components/ResultCount basic usage 1`] = `
 <span
   className="AutoUI_ui_ResultCount-9"
+  data-testid="xpui-resultCount"
 >
   <span
     className="AutoUI_ui_ResultCount-13"
@@ -25591,6 +25620,7 @@ exports[`Storyshots UI Components/ResultCount basic usage 1`] = `
 exports[`Storyshots UI Components/ResultCount missing props (does component explode?) 1`] = `
 <span
   className="AutoUI_ui_ResultCount-9"
+  data-testid="xpui-resultCount"
 >
   <span
     className="AutoUI_ui_ResultCount-13"
@@ -25604,6 +25634,7 @@ exports[`Storyshots UI Components/ResultCount missing props (does component expl
 exports[`Storyshots UI Components/ResultCount usage with single item result 1`] = `
 <span
   className="AutoUI_ui_ResultCount-9"
+  data-testid="xpui-resultCount"
 >
   <span
     className="AutoUI_ui_ResultCount-13"

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -464,7 +464,7 @@ exports[`Storyshots Form Components/SolutionForm 2 attempts are taken 1`] = `
       color="normal"
       component="button"
       contentStyle="normal"
-      data-test="solutionSubmit"
+      data-testid="xpui-solutionForm-button-submit"
       disabled={false}
       icon=""
       iconProps={Object {}}
@@ -508,7 +508,7 @@ exports[`Storyshots Form Components/SolutionForm custom submit callback is passe
       color="normal"
       component="button"
       contentStyle="normal"
-      data-test="solutionSubmit"
+      data-testid="xpui-solutionForm-button-submit"
       disabled={false}
       icon=""
       iconProps={Object {}}
@@ -551,7 +551,7 @@ exports[`Storyshots Form Components/SolutionForm max of 5 attempts allowed 1`] =
       color="normal"
       component="button"
       contentStyle="normal"
-      data-test="solutionSubmit"
+      data-testid="xpui-solutionForm-button-submit"
       disabled={false}
       icon=""
       iconProps={Object {}}
@@ -594,7 +594,7 @@ exports[`Storyshots Form Components/SolutionForm missing props (does component e
       color="normal"
       component="button"
       contentStyle="normal"
-      data-test="solutionSubmit"
+      data-testid="xpui-solutionForm-button-submit"
       disabled={false}
       icon=""
       iconProps={Object {}}
@@ -637,7 +637,7 @@ exports[`Storyshots Form Components/SolutionForm submitting is in progress 1`] =
       color="normal"
       component="button"
       contentStyle="normal"
-      data-test="solutionSubmit"
+      data-testid="xpui-solutionForm-button-submit"
       disabled={true}
       icon=""
       iconProps={Object {}}
@@ -680,7 +680,7 @@ exports[`Storyshots Form Components/SolutionForm with disabled button 1`] = `
       color="normal"
       component="button"
       contentStyle="normal"
-      data-test="solutionSubmit"
+      data-testid="xpui-solutionForm-button-submit"
       disabled={true}
       icon=""
       iconProps={Object {}}
@@ -2944,7 +2944,7 @@ exports[`Storyshots UI Components/ApplicantBadge/Debug missing props (does compo
 exports[`Storyshots UI Components/ApplicantGrid basic usage 1`] = `
 <div
   className="AutoUI_ui_ApplicantGrid-11"
-  data-test="applicants"
+  data-testid="xpui-applicantGrid"
   onKeyPress={[Function]}
   tabIndex={0}
 >
@@ -3043,7 +3043,7 @@ exports[`Storyshots UI Components/ApplicantGrid basic usage 1`] = `
 exports[`Storyshots UI Components/ApplicantGrid/Debug missing props (does component explode?) 1`] = `
 <div
   className="AutoUI_ui_ApplicantGrid-11"
-  data-test="applicants"
+  data-testid="xpui-applicantGrid"
   onKeyPress={[Function]}
   tabIndex={0}
 >
@@ -4590,7 +4590,9 @@ exports[`Storyshots UI Components/Button/With Knobs all effects 1`] = `
 <button
   className="    "
 >
-  <span>
+  <span
+    data-testid="xpui-button"
+  >
     This is a button
   </span>
 </button>
@@ -15755,9 +15757,11 @@ exports[`Storyshots UI Components/DataGrid loading 1`] = `
 exports[`Storyshots UI Components/DataGrid/Debug missing props (does component explode?) 1`] = `
 <div
   className="AutoUI_ui_DataGrid-45"
+  data-testid="xpui-dataGrid-container"
 >
   <div
     className="AutoUI_ui_DataGrid-51"
+    data-testid="xpui-dataGrid-grid"
   >
     <ReactDataGrid
       cellNavigationMode="none"
@@ -15811,7 +15815,7 @@ exports[`Storyshots UI Components/Dropdown SelectBox example 1`] = `
 >
   <div
     className="AutoUI_ui_Dropdown-24 AutoUI_ui_Dropdown-44"
-    data-testid="xpui-dropdown__button"
+    data-testid="xpui-dropdown-button"
     onClick={[Function]}
   >
     <SvgIcon
@@ -15820,7 +15824,7 @@ exports[`Storyshots UI Components/Dropdown SelectBox example 1`] = `
     />
     <span
       className="AutoUI_ui_Dropdown-40"
-      data-testid="xpui-dropdown__button__label"
+      data-testid="xpui-dropdown-button-label"
     >
       This is a Dropdown
     </span>
@@ -15835,7 +15839,7 @@ exports[`Storyshots UI Components/Dropdown SelectBox example 1`] = `
   </div>
   <div
     className="AutoUI_ui_Dropdown-50     "
-    data-testid="xpui-dropdown__children"
+    data-testid="xpui-dropdown-children"
   >
     <SelectBox
       areItemsToggleable={true}
@@ -15895,12 +15899,12 @@ exports[`Storyshots UI Components/Dropdown SelectBox example using radio buttons
 >
   <div
     className="AutoUI_ui_Dropdown-24 AutoUI_ui_Dropdown-44"
-    data-testid="xpui-dropdown__button"
+    data-testid="xpui-dropdown-button"
     onClick={[Function]}
   >
     <span
       className="AutoUI_ui_Dropdown-40"
-      data-testid="xpui-dropdown__button__label"
+      data-testid="xpui-dropdown-button-label"
     >
       registered
     </span>
@@ -15915,7 +15919,7 @@ exports[`Storyshots UI Components/Dropdown SelectBox example using radio buttons
   </div>
   <div
     className="AutoUI_ui_Dropdown-50     "
-    data-testid="xpui-dropdown__children"
+    data-testid="xpui-dropdown-children"
   >
     <SelectBox
       areItemsToggleable={true}
@@ -15975,12 +15979,12 @@ exports[`Storyshots UI Components/Dropdown close Dropdown from children 1`] = `
 >
   <div
     className="AutoUI_ui_Dropdown-24 "
-    data-testid="xpui-dropdown__button"
+    data-testid="xpui-dropdown-button"
     onClick={[Function]}
   >
     <span
       className="AutoUI_ui_Dropdown-40"
-      data-testid="xpui-dropdown__button__label"
+      data-testid="xpui-dropdown-button-label"
     >
       <h1>
         Click to open!
@@ -15989,11 +15993,11 @@ exports[`Storyshots UI Components/Dropdown close Dropdown from children 1`] = `
   </div>
   <div
     className="AutoUI_ui_Dropdown-50    AutoUI_ui_Dropdown-111 "
-    data-testid="xpui-dropdown__children"
+    data-testid="xpui-dropdown-children"
   >
     <div
       className="AutoUI_ui_Dropdown-71 "
-      data-testid="xpui-dropdown__children__tooltip"
+      data-testid="xpui-dropdown-children-tooltip"
     >
       <CloseButton
         closeDropdown={[Function]}
@@ -16011,7 +16015,7 @@ exports[`Storyshots UI Components/Dropdown icon only button 1`] = `
 >
   <div
     className="AutoUI_ui_Dropdown-24 AutoUI_ui_Dropdown-44"
-    data-testid="xpui-dropdown__button"
+    data-testid="xpui-dropdown-button"
     onClick={[Function]}
   >
     <SvgIcon
@@ -16021,7 +16025,7 @@ exports[`Storyshots UI Components/Dropdown icon only button 1`] = `
   </div>
   <div
     className="AutoUI_ui_Dropdown-50     "
-    data-testid="xpui-dropdown__children"
+    data-testid="xpui-dropdown-children"
   >
     <div
       key=".0"
@@ -16111,7 +16115,7 @@ exports[`Storyshots UI Components/Dropdown labeled button 1`] = `
 >
   <div
     className="AutoUI_ui_Dropdown-24 "
-    data-testid="xpui-dropdown__button"
+    data-testid="xpui-dropdown-button"
     onClick={[Function]}
   >
     <SvgIcon
@@ -16120,7 +16124,7 @@ exports[`Storyshots UI Components/Dropdown labeled button 1`] = `
     />
     <span
       className="AutoUI_ui_Dropdown-40"
-      data-testid="xpui-dropdown__button__label"
+      data-testid="xpui-dropdown-button-label"
     >
       Add to List
     </span>
@@ -16135,7 +16139,7 @@ exports[`Storyshots UI Components/Dropdown labeled button 1`] = `
   </div>
   <div
     className="AutoUI_ui_Dropdown-50     "
-    data-testid="xpui-dropdown__children"
+    data-testid="xpui-dropdown-children"
   >
     <div
       key=".0"
@@ -16200,12 +16204,12 @@ exports[`Storyshots UI Components/Dropdown tooltip display 1`] = `
 >
   <div
     className="AutoUI_ui_Dropdown-24 "
-    data-testid="xpui-dropdown__button"
+    data-testid="xpui-dropdown-button"
     onClick={[Function]}
   >
     <span
       className="AutoUI_ui_Dropdown-40"
-      data-testid="xpui-dropdown__button__label"
+      data-testid="xpui-dropdown-button-label"
     >
       <Button
         block={false}
@@ -16233,11 +16237,11 @@ exports[`Storyshots UI Components/Dropdown tooltip display 1`] = `
   </div>
   <div
     className="AutoUI_ui_Dropdown-50    AutoUI_ui_Dropdown-111 "
-    data-testid="xpui-dropdown__children"
+    data-testid="xpui-dropdown-children"
   >
     <div
       className="AutoUI_ui_Dropdown-71 "
-      data-testid="xpui-dropdown__children__tooltip"
+      data-testid="xpui-dropdown-children-tooltip"
     >
       Anything here
     </div>
@@ -20517,6 +20521,7 @@ exports[`Storyshots UI Components/Filters/Debug missing props for Filter (does c
   <Label />
   <div
     className="AutoUI_ui_Filters_Filter-17"
+    data-testid="xpui-filters-filter"
   />
 </Fragment>
 `;
@@ -20524,18 +20529,22 @@ exports[`Storyshots UI Components/Filters/Debug missing props for Filter (does c
 exports[`Storyshots UI Components/Filters/Debug missing props for Group (does components explode?) 1`] = `
 <div
   className="AutoUI_ui_Filters_Group-17"
+  data-testid="xpui-filters-group"
 />
 `;
 
 exports[`Storyshots UI Components/Filters/Debug missing props for Heading (does components explode?) 1`] = `
 <div
-  className="AutoUI_ui_Filters_Heading-22 AutoUI_typo-22 AutoUI_ui_Filters_Heading-45"
+  className="AutoUI_ui_Filters_Heading-22 AutoUI_typo-22 AutoUI_ui_Filters_Heading-48"
+  data-testid="xpui-filters-heading"
 >
   <div
-    className="AutoUI_ui_Filters_Heading-51"
+    className="AutoUI_ui_Filters_Heading-54"
+    data-testid="xpui-filters-heading-children"
   />
   <div
-    className="AutoUI_ui_Filters_Heading-55"
+    className="AutoUI_ui_Filters_Heading-58"
+    data-testid="xpui-filters-heading-arrow"
   >
     <SvgIcon
       color="grayscarpaflow"
@@ -20548,6 +20557,7 @@ exports[`Storyshots UI Components/Filters/Debug missing props for Heading (does 
 exports[`Storyshots UI Components/Filters/Debug missing props for Label (does components explode?) 1`] = `
 <div
   className="AutoUI_ui_Filters_Label-17 AutoUI_typo-34"
+  data-testid="xpui-filters-label"
 />
 `;
 
@@ -22153,6 +22163,7 @@ exports[`Storyshots UI Components/HeadingWithQuickSearch self-controlled sidebar
 exports[`Storyshots UI Components/HeadingWithQuickSearch/Debug missing props (does component explode?) 1`] = `
 <div
   className="AutoUI_ui_HeadingWithQuickSearch-18 AutoUI_typo-22"
+  data-testid="xpui-headingWithQuickSearch-container"
 >
   <QuickSearchButton
     onClick={[Function]}
@@ -22182,9 +22193,10 @@ exports[`Storyshots UI Components/HeadingWithQuickSearch/Debug with action handl
 exports[`Storyshots UI Components/HeadingWithQuickSearch/Debug without wrapper 1`] = `
 <div
   className="AutoUI_ui_HeadingWithQuickSearch-18 AutoUI_typo-22"
+  data-testid="xpui-headingWithQuickSearch-container"
 >
   <div
-    className="AutoUI_ui_HeadingWithQuickSearch-30"
+    className="AutoUI_ui_HeadingWithQuickSearch-33"
   >
     <SvgIcon
       color="frenchGrayDarker"
@@ -22421,7 +22433,7 @@ exports[`Storyshots UI Components/ListExclusionFormPopup/Debug missing props (do
       className="AutoUI_ui_ListExclusionFormPopup-52"
     >
       <InputField
-        data-testid="exclusion-comment"
+        data-testid="xpui-listExclusionFormPopup-input-comment"
         isInvalid={false}
         label="Add a comment"
         name="reason"
@@ -22433,7 +22445,7 @@ exports[`Storyshots UI Components/ListExclusionFormPopup/Debug missing props (do
         value=""
       />
       <div
-        className="AutoUI_ui_ListExclusionFormPopup-82"
+        className="AutoUI_ui_ListExclusionFormPopup-85"
       >
         <Button
           block={false}
@@ -22441,7 +22453,7 @@ exports[`Storyshots UI Components/ListExclusionFormPopup/Debug missing props (do
           color="normal"
           component="button"
           contentStyle="normal"
-          data-testid="exclusion-cancel"
+          data-testid="xpui-listExclusionFormPopup-button-cancel"
           disabled={false}
           icon=""
           iconProps={Object {}}
@@ -22465,7 +22477,7 @@ exports[`Storyshots UI Components/ListExclusionFormPopup/Debug missing props (do
           color="normal"
           component="button"
           contentStyle="normal"
-          data-testid="exclusion-submit"
+          data-testid="xpui-listExclusionFormPopup-button-submit"
           disabled={true}
           icon=""
           iconProps={Object {}}
@@ -22851,15 +22863,15 @@ exports[`Storyshots UI Components/MetaGroup standalone composed with children 1`
 exports[`Storyshots UI Components/MetaGroup/Debug missing props (does component explode?) 1`] = `
 <div
   className="AutoUI_ui_MetaGroup-10"
-  data-testid="xpui-metaGroup__layout"
+  data-testid="xpui-metaGroup-layout"
 >
   <div
     className="AutoUI_ui_MetaGroup-15"
-    data-testid="xpui-metaGroup__mainBodyColumn"
+    data-testid="xpui-metaGroup-mainBodyColumn"
   />
   <div
     className="AutoUI_ui_MetaGroup-21"
-    data-testid="xpui-metaGroup__secondaryColumns"
+    data-testid="xpui-metaGroup-secondaryColumns"
   />
 </div>
 `;
@@ -25595,6 +25607,7 @@ exports[`Storyshots UI Components/QuickSearchButton basic usage 1`] = `
 exports[`Storyshots UI Components/QuickSearchButton/Debug missing props (does component explode?) 1`] = `
 <div
   className="AutoUI_ui_QuickSearchButton-15"
+  data-testid="xpui-quickSearchButton"
   onClick={[Function]}
 >
   <SvgIcon
@@ -26118,7 +26131,7 @@ exports[`Storyshots UI Components/RoadmapLevel centered state with CTA button 1`
     color="normal"
     component="button"
     contentStyle="normal"
-    data-test="roadmapStart"
+    data-testid="xpui-roadmapLevel-button-cta"
     disabled={false}
     icon=""
     iconProps={Object {}}

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -10667,6 +10667,7 @@ exports[`Storyshots UI Components/DataGrid default 1`] = `
       ]
     }
     handleGridSort={[Function]}
+    rowsCount={1000}
     sortColumn="email"
     sortDirection="DESC"
     visibleColumns={
@@ -15721,6 +15722,7 @@ exports[`Storyshots UI Components/DataGrid loading 1`] = `
     }
     handleGridSort={[Function]}
     isLoading={true}
+    rowsCount={1000}
     sortColumn="email"
     sortDirection="DESC"
     visibleColumns={
@@ -15752,10 +15754,10 @@ exports[`Storyshots UI Components/DataGrid loading 1`] = `
 
 exports[`Storyshots UI Components/DataGrid/Debug missing props (does component explode?) 1`] = `
 <div
-  className="AutoUI_ui_DataGrid-47"
+  className="AutoUI_ui_DataGrid-45"
 >
   <div
-    className="AutoUI_ui_DataGrid-53"
+    className="AutoUI_ui_DataGrid-51"
   >
     <ReactDataGrid
       cellNavigationMode="none"
@@ -36950,6 +36952,7 @@ exports[`Storyshots UI Components/SearchResult/Debug missing props (does compone
   />
   <DataGrid
     applicants={Array []}
+    rowsCount={0}
     sortColumn=""
     sortDirection="NONE"
     visibleColumns={Array []}

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -22646,15 +22646,16 @@ exports[`Storyshots UI Components/ListsEditor basic 1`] = `
 
 exports[`Storyshots UI Components/ListsEditor missing props (does component explode?) 1`] = `
 <div
-  className="AutoUI_ui_ListsEditor-53"
+  className="AutoUI_ui_ListsEditor-68"
+  data-testid="xpui-listsEditor"
 >
   <h1
-    className="AutoUI_ui_ListsEditor-59 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34"
+    className="AutoUI_ui_ListsEditor-74 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34"
   >
     Edit 
   </h1>
   <Tabs
-    className="AutoUI_ui_ListsEditor-92"
+    className="AutoUI_ui_ListsEditor-107"
     defaultActiveTabKey={0}
   >
     <Tab
@@ -22686,11 +22687,11 @@ exports[`Storyshots UI Components/ListsEditor missing props (does component expl
           visibleItems={7}
         />
         <div
-          className="AutoUI_ui_ListsEditor-68"
+          className="AutoUI_ui_ListsEditor-83"
         >
           <Button
             block={false}
-            className="AutoUI_ui_ListsEditor-77"
+            className="AutoUI_ui_ListsEditor-92"
             color="normal"
             component="button"
             contentStyle="normal"
@@ -22713,7 +22714,7 @@ exports[`Storyshots UI Components/ListsEditor missing props (does component expl
           </Button>
           <Button
             block={false}
-            className="AutoUI_ui_ListsEditor-77 AutoUI_ui_ListsEditor-88"
+            className="AutoUI_ui_ListsEditor-92 AutoUI_ui_ListsEditor-103"
             color="normal"
             component="button"
             contentStyle="normal"
@@ -22765,11 +22766,11 @@ exports[`Storyshots UI Components/ListsEditor missing props (does component expl
           visibleItems={7}
         />
         <div
-          className="AutoUI_ui_ListsEditor-68"
+          className="AutoUI_ui_ListsEditor-83"
         >
           <Button
             block={false}
-            className="AutoUI_ui_ListsEditor-77"
+            className="AutoUI_ui_ListsEditor-92"
             color="normal"
             component="button"
             contentStyle="normal"
@@ -22792,7 +22793,7 @@ exports[`Storyshots UI Components/ListsEditor missing props (does component expl
           </Button>
           <Button
             block={false}
-            className="AutoUI_ui_ListsEditor-77 AutoUI_ui_ListsEditor-88"
+            className="AutoUI_ui_ListsEditor-92 AutoUI_ui_ListsEditor-103"
             color="normal"
             component="button"
             contentStyle="normal"

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -2953,7 +2953,7 @@ exports[`Storyshots UI Components/ApplicantGrid basic usage 1`] = `
     increment={2}
     inserted={false}
     isFetching={false}
-    itemClass="AutoUI_ui_ApplicantGrid-19"
+    itemClass="AutoUI_ui_ApplicantGrid-20"
     items={
       Array [
         <StoryApplicantBadge
@@ -3033,7 +3033,7 @@ exports[`Storyshots UI Components/ApplicantGrid basic usage 1`] = `
         />,
       ]
     }
-    listClass="AutoUI_ui_ApplicantGrid-15"
+    listClass="AutoUI_ui_ApplicantGrid-16"
     viewMore={[Function]}
     visible={3}
   />
@@ -3052,9 +3052,9 @@ exports[`Storyshots UI Components/ApplicantGrid/Debug missing props (does compon
     increment={50}
     inserted={false}
     isFetching={false}
-    itemClass="AutoUI_ui_ApplicantGrid-19"
+    itemClass="AutoUI_ui_ApplicantGrid-20"
     items={Array []}
-    listClass="AutoUI_ui_ApplicantGrid-15"
+    listClass="AutoUI_ui_ApplicantGrid-16"
     viewMore={[Function]}
     visible={50}
   />
@@ -16518,7 +16518,9 @@ exports[`Storyshots UI Components/Email HTML body test 1`] = `
   <div
     className="AutoUI_ui_Email-88 AutoUI_typo-53 AutoUI_typo-40"
   >
-    <span>
+    <span
+      key="outer"
+    >
       <font
         key="0"
         size="6"
@@ -16934,7 +16936,9 @@ exports[`Storyshots UI Components/Email initial open body 1`] = `
   <div
     className="AutoUI_ui_Email-88 AutoUI_typo-53 AutoUI_typo-40"
   >
-    <span>
+    <span
+      key="outer"
+    >
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque tempus molestie purus sed suscipit. Duis non ultricies velit, eu laoreet augue. Nullam turpis massa, scelerisque at tempus eu, placerat vitae orci. Nam at sem pellentesque, viverra risus id, volutpat nisl. In hac habitasse platea dictumst. Integer et dignissim eros. Quisque vel sem vel magna congue consectetur ac vel ex. Pellentesque pulvinar congue lacinia. Sed finibus ex non lorem sodales, ac pulvinar urna placerat. Aenean vel sodales libero, ac egestas velit. Nulla turpis dolor, dapibus ut diam sed, aliquam vestibulum nibh. In a ullamcorper libero. Pellentesque mattis, dui in molestie cursus, est risus convallis ligula, nec hendrerit sem odio eu elit. Aliquam sapien lacus, tincidunt rhoncus malesuada at, finibus non dolor. Pellentesque interdum nibh eu tempor pretium.
     </span>
   </div>
@@ -17001,7 +17005,9 @@ exports[`Storyshots UI Components/Email initial open body and content with lineb
   <div
     className="AutoUI_ui_Email-88 AutoUI_typo-53 AutoUI_typo-40"
   >
-    <div>
+    <div
+      key="outer"
+    >
       <p
         key="0"
       >
@@ -20346,7 +20352,7 @@ exports[`Storyshots UI Components/Filters example of complete composition with a
 
 exports[`Storyshots UI Components/Filters/Debug centered Filter Groups 1`] = `
 <div
-  className="AutoUI_ui_Filters_Container-17 "
+  className="AutoUI_ui_Filters_Container-19 "
 >
   <Container
     bodyWrapper={[Function]}
@@ -20475,7 +20481,7 @@ exports[`Storyshots UI Components/Filters/Debug centered Filter Groups 1`] = `
 
 exports[`Storyshots UI Components/Filters/Debug missing props for Container (does components explode?) 1`] = `
 <div
-  className="AutoUI_ui_Filters_Container-17 "
+  className="AutoUI_ui_Filters_Container-19 "
 />
 `;
 

--- a/src/components/ui/ApplicantBadge.js
+++ b/src/components/ui/ApplicantBadge.js
@@ -19,15 +19,15 @@ type Info = {
   value: string,
   label: string,
   tip?: string
-};
+}
 
 type Action = {
   key: string,
   icon: () => Element<*>,
   onClick: (?string) => void
-};
+}
 
-type Status = 'accepted' | 'excluded' | '';
+type Status = 'accepted' | 'excluded' | ''
 
 type Props = {
   id: number,
@@ -42,7 +42,7 @@ type Props = {
   actions: Array<Action>,
   status: Status,
   applicantStatus?: string
-};
+}
 
 const cmz = require('cmz')
 
@@ -344,49 +344,49 @@ class ApplicantBadge extends PureComponent<Props> {
     actions: [],
     info: [],
     status: ''
-  };
+  }
 
   renderStatusIndicator = () => {
     const { status } = this.props
     const style = status && statusDotStyles[status]
     return style && <span className={style} />
-  };
+  }
 
   handleBadgeClick = (event: SyntheticEvent<>) => {
     event.stopPropagation()
     const { id, onClick } = this.props
     onClick && onClick(id)
-  };
+  }
 
   handleActionClick = (onClick: (?string) => void, actionIdAttr: string) => () => {
     onClick && onClick(actionIdAttr)
-  };
+  }
 
   infoLabel = (info: Info) => (
     <div>
       <span className={cx.label}>{info.label}</span>
       <span className={cx.value}>{info.value}</span>
     </div>
-  );
+  )
 
   renderInfoLabelDropdown = (key: number, info: Info) => (
     <Dropdown key={key} tooltip hover label={this.infoLabel(info)}>
       {info.tip && <div className={cx.tip}>{info.tip}</div>}
     </Dropdown>
-  );
+  )
 
   renderInfoItems = () => {
     const filteredInfos = this.props.info.filter(each => each.value)
     return filteredInfos.map((info, key) =>
       info.tip ? this.renderInfoLabelDropdown(key, info) : this.infoLabel(info)
     )
-  };
+  }
 
   renderInfosViewMore = (amount: string, action: () => void) => (
     <div className={[cx.info, cx.moreinfos].join(' ')} onClick={action}>
       {`+ ${amount} info`}
     </div>
-  );
+  )
 
   mapInfosToRender = () => {
     const { info } = this.props
@@ -402,13 +402,13 @@ class ApplicantBadge extends PureComponent<Props> {
         />
       )
     )
-  };
+  }
 
   renderTagsViewMore = (amount: string, action: () => void) => (
     <div className={[cx.tag, cx.moretags, cx.purelabel].join(' ')} onClick={action}>
       {`+ ${amount} more`}
     </div>
-  );
+  )
 
   mapTagsToRender = () => {
     const { tags } = this.props
@@ -424,7 +424,7 @@ class ApplicantBadge extends PureComponent<Props> {
         />
       )
     )
-  };
+  }
 
   renderActions = () => {
     const { id, actions } = this.props
@@ -443,7 +443,7 @@ class ApplicantBadge extends PureComponent<Props> {
         )
       )
     })
-  };
+  }
 
   render () {
     const { id, active, name, email, avatar, children, applicantStatus } = this.props

--- a/src/components/ui/ApplicantBadge.js
+++ b/src/components/ui/ApplicantBadge.js
@@ -452,33 +452,33 @@ class ApplicantBadge extends PureComponent<Props> {
       <div
         onClick={this.handleBadgeClick}
         className={[cx.wrapper, cx.displayControlsOnHover, active ? cx.active : ''].join(' ')}
-        data-testid='xp-ui-applicantBadge-container'
+        data-testid='xpui-applicantBadge-container'
       >
-        <div className={cx.name} data-testid='xp-ui-applicantBadge-name'>
-          <div className={cx.nameInner} title={name || email} data-testid='xp-ui-applicantBadge-name-inner'>
+        <div className={cx.name} data-testid='xpui-applicantBadge-name'>
+          <div className={cx.nameInner} title={name || email} data-testid='xpui-applicantBadge-name-inner'>
             {name || email}
           </div>
           {this.renderStatusIndicator()}
         </div>
-        <div className={cx.avatar} data-testid='xp-ui-applicantBadge-avatar'>
+        <div className={cx.avatar} data-testid='xpui-applicantBadge-avatar'>
           {avatar || (
             <Avatar src={`https://www.gravatar.com/avatar/${md5(email)}?s=65`} alt={name || 'avatar'} size={65} />
           )}
         </div>
-        <div className={cx.controls} data-testid='xp-ui-applicantBadge-controls'>
+        <div className={cx.controls} data-testid='xpui-applicantBadge-controls'>
           {this.renderActions()}
         </div>
-        <div className={cx.infos} data-testid='xp-ui-applicantBadge-infos'>
+        <div className={cx.infos} data-testid='xpui-applicantBadge-infos'>
           {this.mapInfosToRender()}
         </div>
-        <div className={cx.applicantStatus} data-testid='xp-ui-applicantBadge-applicantStatus'>
+        <div className={cx.applicantStatus} data-testid='xpui-applicantBadge-applicantStatus'>
           {applicantStatus}
         </div>
-        <div className={cx.tags} data-testid='xp-ui-applicantBadge-tags'>
+        <div className={cx.tags} data-testid='xpui-applicantBadge-tags'>
           {this.mapTagsToRender()}
         </div>
         {children && (
-          <div className={cx.children} data-testid='xp-ui-applicantBadge-children'>
+          <div className={cx.children} data-testid='xpui-applicantBadge-children'>
             {children}
           </div>
         )}

--- a/src/components/ui/ApplicantGrid.js
+++ b/src/components/ui/ApplicantGrid.js
@@ -10,6 +10,7 @@ const cmz = require('cmz')
 const cx = {
   wrapper: cmz(`
     outline: none
+    flex: 1
   `),
 
   list: cmz(`

--- a/src/components/ui/Button.js
+++ b/src/components/ui/Button.js
@@ -13,9 +13,9 @@ import typo from '../../styles/typo'
 
 const cmz = require('cmz')
 
-export type Size = 'normal' | 'large' | 'small';
-export type Color = 'normal' | 'monochrome' | 'silver' | 'gray' | 'grayPink';
-export type ContentStyle = 'normal' | 'openSans' | 'sourceSansPro';
+export type Size = 'normal' | 'large' | 'small'
+export type Color = 'normal' | 'monochrome' | 'silver' | 'gray' | 'grayPink'
+export type ContentStyle = 'normal' | 'openSans' | 'sourceSansPro'
 
 type Props = {
   className: string | CmzAtom,
@@ -38,7 +38,7 @@ type Props = {
   icon?: Icon | '',
   iconProps: Object,
   contentStyle: ContentStyle
-};
+}
 
 const baseStyles = {
   root: cmz(`
@@ -406,7 +406,7 @@ class Button extends PureComponent<Props> {
     wide: false,
     selectbox: false,
     readOnly: false
-  };
+  }
 
   render () {
     const {

--- a/src/components/ui/DataGrid.js
+++ b/src/components/ui/DataGrid.js
@@ -10,8 +10,6 @@ import type { Applicant } from '../../utils/types'
 
 const cmz = require('cmz')
 
-const RENDER_ROWS_COUNT = 1000
-
 const selectors = Data.Selectors
 
 // Given the design of React-Data-Grid, it relies on minHeight to calculate the visible area and show/hide
@@ -79,6 +77,7 @@ type Props = {
   visibleColumns: Array<Object>,
   sortDirection: SortDirection,
   sortColumn: string,
+  rowsCount: number,
   handleGridSort: (sortColumn: string, sortDirection: SortDirection) => void
 }
 
@@ -91,7 +90,8 @@ const DataGrid = ({
   sortDirection,
   handleGridSort,
   applicants,
-  isLoading
+  isLoading,
+  rowsCount
 }: Props) =>
   (
     <div className={cx.gridContainer}>
@@ -104,7 +104,7 @@ const DataGrid = ({
         <ReactDataGrid
           columns={visibleColumns}
           rowGetter={getRow(applicants)}
-          rowsCount={RENDER_ROWS_COUNT}
+          rowsCount={rowsCount}
           headerFiltersHeight={0}
           onGridSort={handleGridSort}
           sortColumn={sortColumn}
@@ -117,7 +117,8 @@ const DataGrid = ({
 
 DataGrid.defaultProps = {
   applicants: [],
-  visibleColumns: []
+  visibleColumns: [],
+  rowsCount: 1000
 }
 
 export default DataGrid

--- a/src/components/ui/DataGrid.js
+++ b/src/components/ui/DataGrid.js
@@ -113,8 +113,7 @@ const DataGrid = ({
         />
       </div>
     </div>
-  </div>
-)
+  )
 
 DataGrid.defaultProps = {
   applicants: [],

--- a/src/components/ui/DataGrid.js
+++ b/src/components/ui/DataGrid.js
@@ -69,7 +69,7 @@ const cx = {
   `)
 }
 
-type SortDirection = 'ASC' | 'DESC' | 'NONE' | '';
+type SortDirection = 'ASC' | 'DESC' | 'NONE' | ''
 
 type Props = {
   isLoading: boolean,
@@ -79,7 +79,7 @@ type Props = {
   sortColumn: string,
   rowsCount: number,
   handleGridSort: (sortColumn: string, sortDirection: SortDirection) => void
-};
+}
 
 const getRows = (applicants: Array<Applicant>) => selectors.getRows({ rows: applicants })
 const getRow = (applicants: Array<Applicant>) => (rowIdx: number) => getRows(applicants)[rowIdx]

--- a/src/components/ui/Dropdown.js
+++ b/src/components/ui/Dropdown.js
@@ -187,28 +187,17 @@ class Dropdown extends PureComponent<Props, State> {
     } = this.props
     const { open } = this.state
 
-    const rootClasses = [
-      styles.dropdown,
-      className || ''
-    ].join(' ')
-    const labelClasses = [
-      styles.label,
-      padded ? styles.padded : ''
-    ].join(' ')
+    const rootClasses = [styles.dropdown, className || ''].join(' ')
+    const labelClasses = [styles.label, padded ? styles.padded : ''].join(' ')
     const contentClasses = [
       styles.content,
       open ? styles.contentVisible : '',
       targetXOrigin === 'right' ? styles.contentRight : '',
       targetYOrigin === 'top' ? styles.contentTop : '',
-      tooltip && children ? (
-        targetYOrigin === 'top' ? styles.contentTooltipTop : styles.contentTooltip
-      ) : '',
+      tooltip && children ? (targetYOrigin === 'top' ? styles.contentTooltipTop : styles.contentTooltip) : '',
       tooltipClassName || ''
     ].join(' ')
-    const tooltipClasses = [
-      styles.tooltip,
-      targetYOrigin === 'top' ? styles.tooltipTop : ''
-    ].join(' ')
+    const tooltipClasses = [styles.tooltip, targetYOrigin === 'top' ? styles.tooltipTop : ''].join(' ')
 
     const handleClick = (e: Object) => {
       e.preventDefault() && e.stopPropagation()
@@ -220,9 +209,7 @@ class Dropdown extends PureComponent<Props, State> {
       React.Children.map(children, child => {
         const { props } = child
         const closeDropdown = props ? props.closeDropdown : false
-        return closeDropdown
-          ? React.cloneElement(child, { closeDropdown: this.close })
-          : child
+        return closeDropdown ? React.cloneElement(child, { closeDropdown: this.close }) : child
       })
 
     const renderContent = () => (
@@ -230,39 +217,39 @@ class Dropdown extends PureComponent<Props, State> {
         className={rootClasses}
         onMouseEnter={hover ? this.open : undefined}
         onMouseLeave={hover ? this.close : undefined}
+        data-testid='xpui-dropdown'
       >
-        <div className={labelClasses} onClick={handleClick}>
+        <div className={labelClasses} onClick={handleClick} data-testid='xpui-dropdown__button'>
           {icon && <SvgIcon icon={icon} color={iconColor} />}
-          {label && <span className={styles.labelElement}>{label}</span>}
+          {label && (
+            <span className={styles.labelElement} data-testid='xpui-dropdown__button__label'>
+              {label}
+            </span>
+          )}
           {indicator && (
             <span className={styles.triangle}>
-              <SvgIcon
-                icon={open ? 'triangleup' : 'triangledown'}
-                color='grayscarpaflow'
-              />
+              <SvgIcon icon={open ? 'triangleup' : 'triangledown'} color='grayscarpaflow' />
             </span>
           )}
         </div>
         {children && (
-          <div className={contentClasses}>
+          <div className={contentClasses} data-testid='xpui-dropdown__children'>
             {tooltip ? (
-              <div className={tooltipClasses}>
+              <div className={tooltipClasses} data-testid='xpui-dropdown__children__tooltip'>
                 {dropdownChildren()}
               </div>
-            ) : dropdownChildren()}
+            ) : (
+              dropdownChildren()
+            )}
           </div>
         )}
       </div>
     )
 
-    const renderContentWrapper = () => open
-      ? (
-        <ClickOutside onClickOutside={this.close}>
-          {renderContent()}
-        </ClickOutside>
-      ) : renderContent()
+    const renderContentWrapper = () =>
+      open ? <ClickOutside onClickOutside={this.close}>{renderContent()}</ClickOutside> : renderContent()
 
-    return (children || label || icon) ? renderContentWrapper() : null
+    return children || label || icon ? renderContentWrapper() : null
   }
 }
 

--- a/src/components/ui/Filters/Container.js
+++ b/src/components/ui/Filters/Container.js
@@ -1,4 +1,5 @@
 // @flow
+/* globals SyntheticKeyboardEvent */
 
 import React from 'react'
 
@@ -8,7 +9,8 @@ import type { Element } from 'react'
 
 export type Props = {
   children: Element<*>,
-  isAccordion?: boolean
+  isAccordion?: boolean,
+  onKeyPress?: (event: SyntheticKeyboardEvent<>) => void
 }
 
 const cmz = require('cmz')
@@ -26,8 +28,13 @@ const cx = {
   `)
 }
 
-const Container = (props: Props) => (
-  <div className={`${cx.filters} ${props.isAccordion ? cx.accordion : ''}`}>{props.children}</div>
+const Container = ({ children, isAccordion, onKeyPress }: Props) => (
+  <div
+    className={`${cx.filters} ${isAccordion ? cx.accordion : ''}`}
+    onKeyPress={onKeyPress}
+  >
+    {children}
+  </div>
 )
 
 export default Container

--- a/src/components/ui/Filters/Filter.js
+++ b/src/components/ui/Filters/Filter.js
@@ -9,7 +9,7 @@ import type { Element } from 'react'
 export type Props = {
   label: Element<*>,
   children: Element<*>
-};
+}
 
 const cmz = require('cmz')
 

--- a/src/components/ui/Filters/Filters.stories.js
+++ b/src/components/ui/Filters/Filters.stories.js
@@ -43,7 +43,7 @@ const Body = ({ children }) => (
 const applicantBadges = getApplicantBadges()
 
 export const StoryFilters = () => (
-  <Filters.Container>
+  <Filters.Container onKeyPress={action('onKeyPress')}>
 
     <GenericCollapsible.Container initialExpanded>
       <GenericCollapsible.Header>
@@ -125,7 +125,7 @@ export const StoryFilters = () => (
 export const StoryFiltersWithAccordion = () => (
   <State initialState={{ expanded: 'filters' }}>
     {({ setState, state }) => (
-      <Filters.Container isAccordion>
+      <Filters.Container isAccordion onKeyPress={action('onKeyPress')}>
 
         <GenericCollapsible.Container
           isAccordion

--- a/src/components/ui/Filters/Group.js
+++ b/src/components/ui/Filters/Group.js
@@ -9,7 +9,7 @@ import type { Element } from 'react'
 export type Props = {
   children: Element<*>,
   isCentered: boolean
-};
+}
 
 const cmz = require('cmz')
 

--- a/src/components/ui/Filters/Group.js
+++ b/src/components/ui/Filters/Group.js
@@ -20,6 +20,7 @@ const cx = {
       box-sizing: border-box
       border-bottom: 1px solid ${theme.lineSilver2}
     }
+
     &:last-of-type,
     &:last-child {
       border-bottom: none

--- a/src/components/ui/Filters/Label.js
+++ b/src/components/ui/Filters/Label.js
@@ -9,7 +9,7 @@ import type { Element } from 'react'
 
 export type Props = {
   children: Element<*>
-};
+}
 
 const cmz = require('cmz')
 

--- a/src/components/ui/Filters/TabButton.js
+++ b/src/components/ui/Filters/TabButton.js
@@ -9,7 +9,7 @@ import theme from '../../../styles/theme'
 export type Props = {
   text: string,
   onClick: (event: any) => void
-};
+}
 
 const cmz = require('cmz')
 

--- a/src/components/ui/HeadingWithQuickSearch.js
+++ b/src/components/ui/HeadingWithQuickSearch.js
@@ -86,20 +86,20 @@ type Props = {
   onQuickSearchChangeValue?: (value: string) => void,
   onQuickSearchSubmit?: (value: string) => void,
   headingAction?: () => void
-};
+}
 
 type State = {
   isSearching: boolean,
   inputValue: string
-};
+}
 
 class HeadingWithQuickSearch extends PureComponent<Props, State> {
   state = {
     isSearching: false,
     inputValue: ''
-  };
+  }
 
-  toggleQuickSearch = (isSearching: boolean): void => this.setState({ isSearching, inputValue: '' });
+  toggleQuickSearch = (isSearching: boolean): void => this.setState({ isSearching, inputValue: '' })
 
   handleChangeValue = (input: Object): void => {
     const newValue = input.target.value
@@ -108,13 +108,13 @@ class HeadingWithQuickSearch extends PureComponent<Props, State> {
     } else {
       this.setState({ inputValue: input.target.value })
     }
-  };
+  }
 
   handleQuickSearchSubmit = (event: SyntheticEvent<HTMLInputElement>): void => {
     event.preventDefault()
     const value = this.props.quickSearchValue || this.state.inputValue
     if (this.props.onQuickSearchSubmit) this.props.onQuickSearchSubmit(value)
-  };
+  }
 
   handleToggleQuickSearch = (isSearching: boolean): (() => void) => {
     return () => {
@@ -124,7 +124,7 @@ class HeadingWithQuickSearch extends PureComponent<Props, State> {
         this.setState({ isSearching, inputValue: '' })
       }
     }
-  };
+  }
 
   renderLeftIcon = (icon: Icon, action?: () => void) => {
     return (
@@ -139,7 +139,7 @@ class HeadingWithQuickSearch extends PureComponent<Props, State> {
         </div>
       ))
     )
-  };
+  }
 
   renderHeadingText = (text: string, action?: () => void) => {
     return action ? (
@@ -149,7 +149,7 @@ class HeadingWithQuickSearch extends PureComponent<Props, State> {
     ) : (
       text
     )
-  };
+  }
 
   renderInput = () => {
     const value = this.props.quickSearchValue || this.state.inputValue || ''
@@ -165,7 +165,7 @@ class HeadingWithQuickSearch extends PureComponent<Props, State> {
         />
       </form>
     )
-  };
+  }
 
   render () {
     const { isQuickSearching, leftIcon, headingAction, text } = this.props

--- a/src/components/ui/HeadingWithQuickSearch.js
+++ b/src/components/ui/HeadingWithQuickSearch.js
@@ -1,0 +1,185 @@
+// @flow
+/* global SyntheticEvent, HTMLInputElement */
+
+import React, { PureComponent } from 'react'
+
+import QuickSearchButton from './QuickSearchButton'
+import SvgIcon from './SvgIcon'
+import InputField from '../forms/InputField'
+
+import theme from '../../styles/theme'
+import { typeface } from '../../styles/typo'
+
+import type { Icon } from './SvgIcon'
+
+const cmz = require('cmz')
+
+const cx = {
+  container: cmz(typeface.extraHeading, `
+    text-transform: uppercase
+    color: ${theme.typoHighlightOnDarkBackground}
+    font-size: 0.9375rem
+    display: flex
+    flex: 1
+    width: 100%
+    height: 100%
+    align-items: center
+    justify-content: stretch
+  `),
+
+  sidebarHeadingIcon: cmz(`
+    & {
+      margin: 0 10px 0 15px
+    }
+
+    & svg {
+      display: block
+    }
+  `),
+
+  headingText: cmz(`
+    &,
+    &:hover {
+      color: ${theme.typoHighlightOnDarkBackground}
+      cursor: pointer
+    }
+  `),
+
+  sidebarHeadingIconRight: cmz(`
+    & {
+      margin: 0 25px 0 auto
+      cursor: pointer
+    }
+
+    & svg {
+      display: block
+    }
+  `),
+
+  inputContainer: cmz(`
+    background-color: ${theme.baseBrighter}
+  `),
+
+  input: cmz(`
+    align-self: stretch
+    width: 100%
+    height: 100% !important
+    border: 0 !important
+    padding: 0 !important
+    margin: 0
+  `),
+
+  inputParent: cmz(`
+    flex: 1
+  `)
+}
+
+type Props = {
+  leftIcon: Icon,
+  text: string,
+  isQuickSearching?: boolean,
+  quickSearchValue?: string,
+  onToggleQuickSearch?: (isEnabled: boolean) => void,
+  onQuickSearchChangeValue?: (value: string) => void,
+  onQuickSearchSubmit?: (value: string) => void,
+  headingAction?: () => void
+}
+
+type State = {
+  isSearching: boolean,
+  inputValue: string
+}
+
+class HeadingWithQuickSearch extends PureComponent<Props, State> {
+  state = {
+    isSearching: false,
+    inputValue: ''
+  }
+
+  toggleQuickSearch = (isSearching: boolean): void => this.setState({ isSearching, inputValue: '' })
+
+  handleChangeValue = (input: Object): void => {
+    const newValue = input.target.value
+    if (this.props.onQuickSearchChangeValue) {
+      this.props.onQuickSearchChangeValue(newValue)
+    } else {
+      this.setState({ inputValue: input.target.value })
+    }
+  }
+
+  handleQuickSearchSubmit = (event: SyntheticEvent<HTMLInputElement>): void => {
+    event.preventDefault()
+    const value = this.props.quickSearchValue || this.state.inputValue
+    if (this.props.onQuickSearchSubmit) this.props.onQuickSearchSubmit(value)
+  }
+
+  handleToggleQuickSearch = (isSearching: boolean) : (() => void) => {
+    return () => {
+      if (this.props.onToggleQuickSearch) {
+        this.props.onToggleQuickSearch(isSearching)
+      } else {
+        this.setState({ isSearching, inputValue: '' })
+      }
+    }
+  }
+
+  renderLeftIcon = (icon: Icon, action?: () => void) => {
+    return icon && (action ? (
+      <a onClick={action} className={[cx.sidebarHeadingIcon, cx.headingText].join(' ')}>
+        <SvgIcon icon={icon} color='frenchGrayDarker' />
+      </a>
+    ) : (
+      <div className={cx.sidebarHeadingIcon}>
+        <SvgIcon icon={icon} color='frenchGrayDarker' />
+      </div>
+    ))
+  }
+
+  renderHeadingText = (text: string, action?: () => void) => {
+    return action ? (
+      <a onClick={action} className={cx.headingText}>
+        {text}
+      </a>
+    ) : text
+  }
+
+  renderInput = () => {
+    const value = this.props.quickSearchValue || this.state.inputValue || ''
+    return (
+      <form className={cx.inputParent} onSubmit={this.handleQuickSearchSubmit}>
+        <InputField
+          autoFocus
+          value={value}
+          onChange={this.handleChangeValue}
+          name='input'
+          className={cx.input}
+          placeholder='Search by Full name or Email Address'
+        />
+      </form>
+    )
+  }
+
+  render () {
+    const { isQuickSearching, leftIcon, headingAction, text } = this.props
+
+    const isQuickSearchActive = isQuickSearching || this.state.isSearching
+
+    return isQuickSearchActive ? (
+      <div className={[cx.container, cx.inputContainer].join(' ')}>
+        {this.renderLeftIcon('magnifier')}
+        {this.renderInput()}
+        <div className={cx.sidebarHeadingIconRight} onClick={this.handleToggleQuickSearch(false)} >
+          <SvgIcon icon={'x'} color='grayscarpaflow' />
+        </div>
+      </div>
+    ) : (
+      <div className={cx.container}>
+        {this.renderLeftIcon(leftIcon, headingAction)}
+        {this.renderHeadingText(text, headingAction)}
+        <QuickSearchButton onClick={this.handleToggleQuickSearch(true)} />
+      </div>
+    )
+  }
+}
+
+export default HeadingWithQuickSearch

--- a/src/components/ui/HeadingWithQuickSearch.stories.js
+++ b/src/components/ui/HeadingWithQuickSearch.stories.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
+
+import State from '../../utils/State'
+
+import HeadingWithQuickSearch from './HeadingWithQuickSearch'
+
+const Heading = ({ children }) => (
+  <div style={{ height: '58px', width: '400px', border: '1px solid rgb(233, 237, 238)', backgroundColor: 'rgb(249, 250, 251)' }}>
+    { children }
+  </div>
+)
+
+storiesOf('UI Components/HeadingWithQuickSearch', module)
+  .add('self-controlled sidebar heading', () => (
+    <Heading>
+      <HeadingWithQuickSearch
+        text='Filters'
+        leftIcon='filters'
+        onQuickSearchSubmit={action('quickSearchSubmit')}
+        headingAction={action('headingAction')}
+      />
+    </Heading>
+  ))
+  .add('fully-controlled sidebar heading', () => (
+    <State initialState={{ isOpen: false, value: '' }}>
+      {({ setState, state }) => (
+        <Heading>
+          <HeadingWithQuickSearch
+            text='Filters'
+            leftIcon='filters'
+            isQuickSearching={state.isOpen}
+            quickSearchValue={state.value}
+            onToggleQuickSearch={(isOpen) => setState({ isOpen })}
+            onQuickSearchChangeValue={(value) => setState({ value })}
+            headingAction={action('headingAction')}
+          />
+        </Heading>
+      )}
+    </State>
+  ))
+
+storiesOf('UI Components/HeadingWithQuickSearch/Debug', module)
+  .add('with action handler', () => (
+    <Heading>
+      <HeadingWithQuickSearch
+        text='Click this arrow'
+        leftIcon='arrowleft'
+        headingAction={action('headingAction')}
+      />
+    </Heading>
+  ))
+  .add('without wrapper', () => (
+    <HeadingWithQuickSearch
+      text='Click this arrow'
+      leftIcon='arrowleft'
+    />
+  ))
+  .add('missing props (does component explode?)', () => (
+    <HeadingWithQuickSearch />
+  ))

--- a/src/components/ui/ListsEditor.js
+++ b/src/components/ui/ListsEditor.js
@@ -14,7 +14,22 @@ import { pluralize } from '../../utils/helpers'
 
 const cmz = require('cmz')
 
-type Status = '' | 'selecting' | 'editing' | 'saving' | 'edited' | 'creating' | 'created' | 'confirm' | 'deleting' | 'deleted' | 'dismissed' | 'archiving' | 'archived' | 'unarchiving' | 'unarchived'
+type Status =
+  | ''
+  | 'selecting'
+  | 'editing'
+  | 'saving'
+  | 'edited'
+  | 'creating'
+  | 'created'
+  | 'confirm'
+  | 'deleting'
+  | 'deleted'
+  | 'dismissed'
+  | 'archiving'
+  | 'archived'
+  | 'unarchiving'
+  | 'unarchived';
 
 type Item = {
   id: number,
@@ -24,7 +39,7 @@ type Item = {
   editing?: string | null,
   hidden?: boolean,
   status?: ?Status
-}
+};
 
 type Props = {
   collectionLabel?: string,
@@ -35,19 +50,19 @@ type Props = {
   onDelete: Function,
   onCreateNew: Function,
   onDismissDeletedMessages: Function
-}
+};
 
 type DeleteConfirmation = {
   activeList: boolean,
   archiveList: boolean
-}
+};
 
 type State = {
   search: string,
   confirmDeletion: DeleteConfirmation,
   activeList: Array<Item>,
   archiveList: Array<Item>
-}
+};
 
 const cx = {
   listseditor: cmz(`
@@ -141,7 +156,7 @@ class ListsEditor extends Component<Props, State> {
     collectionLabel: 'Collection',
     title: '',
     list: []
-  }
+  };
 
   state = {
     search: '',
@@ -151,7 +166,7 @@ class ListsEditor extends Component<Props, State> {
     },
     activeList: this.props.list.filter(item => !item.archived),
     archiveList: this.props.list.filter(item => item.archived)
-  }
+  };
 
   componentDidUpdate (prevProps: Props) {
     if (!Object.is(prevProps, this.props)) {
@@ -166,21 +181,21 @@ class ListsEditor extends Component<Props, State> {
     }
   }
 
-  getCurrentListName = (active: boolean = true) => active ? 'activeList' : 'archiveList'
+  getCurrentListName = (active: boolean = true) => (active ? 'activeList' : 'archiveList');
 
   getSelection = (active: boolean = true) => {
     const currentList = this.state[this.getCurrentListName(active)] || []
     return currentList.filter(each => each.selected)
-  }
+  };
 
   handleSearch = (search: string) => {
     this.setState({ search })
-  }
+  };
 
   handleSelect = (item: Item, active: boolean = true) => {
     const currentListName = this.getCurrentListName(active)
     const currentList = this.state[currentListName] || []
-    const updatedList = currentList.map(each => each.id === item.id ? { ...item } : each)
+    const updatedList = currentList.map(each => (each.id === item.id ? { ...item } : each))
     const selection = updatedList.filter(each => each.selected)
     this.setState(preState => ({
       ...preState,
@@ -190,28 +205,28 @@ class ListsEditor extends Component<Props, State> {
         ...{ [currentListName]: preState.confirmDeletion[currentListName] && selection.length > 0 }
       }
     }))
-  }
+  };
 
   handleEdit = (item: Item) => {
     const { onEdit } = this.props
     onEdit && onEdit(item)
-  }
+  };
 
   handleArchiveItem = (item: Item) => {
     const { onArchive } = this.props
     onArchive && onArchive([item])
-  }
+  };
 
   handleArchive = (event: any, active: boolean = true) => {
     event && event.stopPropagation()
     const { onArchive } = this.props
     onArchive && onArchive(this.getSelection(active))
-  }
+  };
 
   handleDeleteItem = (item: Item) => {
     const { onDelete } = this.props
     onDelete && onDelete([item])
-  }
+  };
 
   handleDelete = (event: any, active: boolean = true) => {
     event && event.stopPropagation()
@@ -222,21 +237,24 @@ class ListsEditor extends Component<Props, State> {
         ...{ [currentListName]: true }
       }
     }))
-  }
+  };
 
   confirmDelete = (event: any, active: boolean = true) => {
     event && event.stopPropagation()
     const currentListName = this.getCurrentListName(active)
     const { onDelete } = this.props
-    this.setState(preState => ({
-      confirmDeletion: {
-        ...preState.confirmDeletion,
-        ...{ [currentListName]: false }
+    this.setState(
+      preState => ({
+        confirmDeletion: {
+          ...preState.confirmDeletion,
+          ...{ [currentListName]: false }
+        }
+      }),
+      () => {
+        onDelete && onDelete(this.getSelection(active))
       }
-    }), () => {
-      onDelete && onDelete(this.getSelection(active))
-    })
-  }
+    )
+  };
 
   cancelDelete = (event: any, active: boolean = true) => {
     event && event.stopPropagation()
@@ -247,19 +265,19 @@ class ListsEditor extends Component<Props, State> {
         ...{ [currentListName]: false }
       }
     }))
-  }
+  };
 
   handleDismissDeletedMessage = (item: Item) => {
     const { onDismissDeletedMessages } = this.props
     if (item && item.id) {
       onDismissDeletedMessages && onDismissDeletedMessages([item])
     }
-  }
+  };
 
   handleCreateNew = (name: string) => {
     const { onCreateNew } = this.props
     onCreateNew && onCreateNew(name)
-  }
+  };
 
   renderListing = (active: boolean = true) => {
     const currentListName = this.getCurrentListName(active)
@@ -287,21 +305,18 @@ class ListsEditor extends Component<Props, State> {
         {confirmDeletion[currentListName] ? (
           <div className={cx.control}>
             <div className={cx.question}>
-              <p>Delete <strong>{selection.length}</strong> {pluralize(selection.length, 'list', true)}</p>
-              <p><strong>Are you sure?</strong></p>
+              <p>
+                Delete <strong>{selection.length}</strong> {pluralize(selection.length, 'list', true)}
+              </p>
+              <p>
+                <strong>Are you sure?</strong>
+              </p>
             </div>
             <div className={cx.answer}>
-              <Button
-                onClick={e => this.cancelDelete(e, active)}
-                pseudolink
-                className={cx.button}
-              >
+              <Button onClick={e => this.cancelDelete(e, active)} pseudolink className={cx.button}>
                 CANCEL
               </Button>
-              <Button
-                onClick={e => this.confirmDelete(e, active)}
-                className={[cx.button, cx.archive].join(' ')}
-              >
+              <Button onClick={e => this.confirmDelete(e, active)} className={[cx.button, cx.archive].join(' ')}>
                 Yes
               </Button>
             </div>
@@ -321,27 +336,23 @@ class ListsEditor extends Component<Props, State> {
               onClick={e => this.handleArchive(e, active)}
               className={[cx.button, cx.archive].join(' ')}
             >
-              {active ? 'Archive' : 'Unarchive' }
+              {active ? 'Archive' : 'Unarchive'}
             </Button>
           </div>
         )}
       </div>
     )
-  }
+  };
 
   render () {
     const { title } = this.props
 
     return (
-      <div className={cx.listseditor}>
+      <div className={cx.listseditor} data-testid='xpui-listsEditor'>
         <h1 className={cx.heading}>Edit {title}</h1>
         <Tabs className={cx.tabs}>
-          <Tab title='Active'>
-            {this.renderListing(true)}
-          </Tab>
-          <Tab title='Archived'>
-            {this.renderListing(false)}
-          </Tab>
+          <Tab title='Active'>{this.renderListing(true)}</Tab>
+          <Tab title='Archived'>{this.renderListing(false)}</Tab>
         </Tabs>
       </div>
     )

--- a/src/components/ui/ListsEditor.js
+++ b/src/components/ui/ListsEditor.js
@@ -29,7 +29,7 @@ type Status =
   | 'archiving'
   | 'archived'
   | 'unarchiving'
-  | 'unarchived';
+  | 'unarchived'
 
 type Item = {
   id: number,
@@ -39,7 +39,7 @@ type Item = {
   editing?: string | null,
   hidden?: boolean,
   status?: ?Status
-};
+}
 
 type Props = {
   collectionLabel?: string,
@@ -50,19 +50,19 @@ type Props = {
   onDelete: Function,
   onCreateNew: Function,
   onDismissDeletedMessages: Function
-};
+}
 
 type DeleteConfirmation = {
   activeList: boolean,
   archiveList: boolean
-};
+}
 
 type State = {
   search: string,
   confirmDeletion: DeleteConfirmation,
   activeList: Array<Item>,
   archiveList: Array<Item>
-};
+}
 
 const cx = {
   listseditor: cmz(`
@@ -156,7 +156,7 @@ class ListsEditor extends Component<Props, State> {
     collectionLabel: 'Collection',
     title: '',
     list: []
-  };
+  }
 
   state = {
     search: '',
@@ -166,7 +166,7 @@ class ListsEditor extends Component<Props, State> {
     },
     activeList: this.props.list.filter(item => !item.archived),
     archiveList: this.props.list.filter(item => item.archived)
-  };
+  }
 
   componentDidUpdate (prevProps: Props) {
     if (!Object.is(prevProps, this.props)) {
@@ -181,16 +181,16 @@ class ListsEditor extends Component<Props, State> {
     }
   }
 
-  getCurrentListName = (active: boolean = true) => (active ? 'activeList' : 'archiveList');
+  getCurrentListName = (active: boolean = true) => (active ? 'activeList' : 'archiveList')
 
   getSelection = (active: boolean = true) => {
     const currentList = this.state[this.getCurrentListName(active)] || []
     return currentList.filter(each => each.selected)
-  };
+  }
 
   handleSearch = (search: string) => {
     this.setState({ search })
-  };
+  }
 
   handleSelect = (item: Item, active: boolean = true) => {
     const currentListName = this.getCurrentListName(active)
@@ -205,28 +205,28 @@ class ListsEditor extends Component<Props, State> {
         ...{ [currentListName]: preState.confirmDeletion[currentListName] && selection.length > 0 }
       }
     }))
-  };
+  }
 
   handleEdit = (item: Item) => {
     const { onEdit } = this.props
     onEdit && onEdit(item)
-  };
+  }
 
   handleArchiveItem = (item: Item) => {
     const { onArchive } = this.props
     onArchive && onArchive([item])
-  };
+  }
 
   handleArchive = (event: any, active: boolean = true) => {
     event && event.stopPropagation()
     const { onArchive } = this.props
     onArchive && onArchive(this.getSelection(active))
-  };
+  }
 
   handleDeleteItem = (item: Item) => {
     const { onDelete } = this.props
     onDelete && onDelete([item])
-  };
+  }
 
   handleDelete = (event: any, active: boolean = true) => {
     event && event.stopPropagation()
@@ -237,7 +237,7 @@ class ListsEditor extends Component<Props, State> {
         ...{ [currentListName]: true }
       }
     }))
-  };
+  }
 
   confirmDelete = (event: any, active: boolean = true) => {
     event && event.stopPropagation()
@@ -254,7 +254,7 @@ class ListsEditor extends Component<Props, State> {
         onDelete && onDelete(this.getSelection(active))
       }
     )
-  };
+  }
 
   cancelDelete = (event: any, active: boolean = true) => {
     event && event.stopPropagation()
@@ -265,19 +265,19 @@ class ListsEditor extends Component<Props, State> {
         ...{ [currentListName]: false }
       }
     }))
-  };
+  }
 
   handleDismissDeletedMessage = (item: Item) => {
     const { onDismissDeletedMessages } = this.props
     if (item && item.id) {
       onDismissDeletedMessages && onDismissDeletedMessages([item])
     }
-  };
+  }
 
   handleCreateNew = (name: string) => {
     const { onCreateNew } = this.props
     onCreateNew && onCreateNew(name)
-  };
+  }
 
   renderListing = (active: boolean = true) => {
     const currentListName = this.getCurrentListName(active)
@@ -342,7 +342,7 @@ class ListsEditor extends Component<Props, State> {
         )}
       </div>
     )
-  };
+  }
 
   render () {
     const { title } = this.props

--- a/src/components/ui/MetaGroup.js
+++ b/src/components/ui/MetaGroup.js
@@ -35,7 +35,7 @@ const cx = {
 
 type Props = {
   mainBodyElement?: Element<*>,
-  secondaryElements: Array<Element<*>>,
+  secondaryElements: Array<Element<*>>
 }
 
 class MetaGroup extends PureComponent<Props, void> {
@@ -46,13 +46,13 @@ class MetaGroup extends PureComponent<Props, void> {
   render () {
     const { mainBodyElement, secondaryElements } = this.props
     return (
-      <div className={cx.layout}>
-        <div className={cx.mainBodyColumn}>
+      <div className={cx.layout} data-testid='xpui-metaGroup__layout'>
+        <div className={cx.mainBodyColumn} data-testid='xpui-metaGroup__mainBodyColumn'>
           {mainBodyElement}
         </div>
-        <div className={cx.secondaryColumns}>
+        <div className={cx.secondaryColumns} data-testid='xpui-metaGroup__secondaryColumns'>
           {secondaryElements.map(element => (
-            <div className={cx.secondaryColumn} key={element.key}>
+            <div className={cx.secondaryColumn} key={element.key} data-testid='xpui-metaGroup__secondaryColumn'>
               {element}
             </div>
           ))}

--- a/src/components/ui/QuickSearchButton.js
+++ b/src/components/ui/QuickSearchButton.js
@@ -10,7 +10,7 @@ const cmz = require('cmz')
 
 type Props = {
   onClick: () => void
-};
+}
 
 const container = cmz(`
   & {

--- a/src/components/ui/QuickSearchButton.js
+++ b/src/components/ui/QuickSearchButton.js
@@ -1,0 +1,46 @@
+// @flow
+
+import React from 'react'
+
+import SvgIcon from './SvgIcon'
+
+import theme from '../../styles/theme'
+
+const cmz = require('cmz')
+
+type Props = {
+  onClick: () => void
+}
+
+const container = cmz(`
+  & {
+    height: 44px
+    width: 44px
+    display: flex
+    align-items: center
+    justify-content: center
+    cursor: pointer
+    margin-left: auto
+    margin-right: 10px
+
+    background: ${theme.baseBrighter}
+    border: 1px solid ${theme.lineSilver2}
+    border-radius: 50%
+  }
+
+  & svg {
+    display: block
+  }
+`)
+
+const QuickSearchButton = ({ onClick }: Props) => (
+  <div className={container} onClick={onClick}>
+    <SvgIcon color='grayscarpaflow' icon='magnifier' hover='default' />
+  </div>
+)
+
+QuickSearchButton.defaultProps = {
+  onClick: () => {}
+}
+
+export default QuickSearchButton

--- a/src/components/ui/QuickSearchButton.stories.js
+++ b/src/components/ui/QuickSearchButton.stories.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
+
+import QuickSearchButton from './QuickSearchButton'
+
+const Body = ({ children }) => (
+  <div style={{ width: '64px', padding: '10px 0' }}>
+    {children}
+  </div>
+)
+
+storiesOf('UI Components/QuickSearchButton', module)
+  .add('basic usage', () => <Body><QuickSearchButton onClick={action('onClick')} /></Body>)
+
+storiesOf('UI Components/QuickSearchButton/Debug', module)
+  .add('missing props (does component explode?)', () => <QuickSearchButton />)

--- a/src/components/ui/ResultCount.js
+++ b/src/components/ui/ResultCount.js
@@ -25,7 +25,7 @@ const ResultCount = ({ items }: Props) => {
   const resultText = parseInt(itemsCount, 10) !== 1 ? 'results' : 'result'
 
   return (
-    <span className={cx.wrapper}>
+    <span className={cx.wrapper} data-testid='xpui-resultCount'>
       <span className={cx.content}>{itemsCount}</span>
       {resultText}
     </span>

--- a/src/components/ui/SearchResult.js
+++ b/src/components/ui/SearchResult.js
@@ -75,6 +75,7 @@ class SearchResult extends Component<Props, void> {
         <DataGrid
           isLoading={isLoading}
           applicants={applicants}
+          rowsCount={applicants.length}
           visibleColumns={visibleColumns}
           sortColumn={sort}
           sortDirection={order}

--- a/src/components/ui/TwoColumnsLayout.js
+++ b/src/components/ui/TwoColumnsLayout.js
@@ -50,7 +50,7 @@ const cx = {
     }
   `),
 
-  sidebarHeadingLink: cmz(`
+  sidebarHeadingAction: cmz(`
     cursor: pointer
   `),
 
@@ -128,7 +128,7 @@ const cx = {
 type Props = {
   sidebar: Element<*>,
   sidebarHeading: string,
-  sidebarHeadingLink?: string,
+  sidebarHeadingAction?: () => void,
   sidebarWidth: number,
   sidebarIcon: Icon,
   scrollableSidebar: boolean,
@@ -150,7 +150,7 @@ class TwoColumnsLayout extends PureComponent<Props, void> {
   }
 
   renderSidebar = () => {
-    const { sidebar, sidebarHeading, sidebarHeadingLink, sidebarWidth, sidebarIcon, scrollableSidebar } = this.props
+    const { sidebar, sidebarHeading, sidebarHeadingAction, sidebarWidth, sidebarIcon, scrollableSidebar } = this.props
 
     const renderHeadingText = () => (
       <Fragment>
@@ -165,19 +165,23 @@ class TwoColumnsLayout extends PureComponent<Props, void> {
       </Fragment>
     )
 
+    const renderHeadingTextComponent = () => sidebarHeadingAction ? (
+      <a onClick={sidebarHeadingAction} className={[cx.sidebarHeading, cx.sidebarHeadingAction].join(' ')}>
+        {renderHeadingText()}
+      </a>
+    ) : (
+      <div className={cx.sidebarHeading}>
+        {renderHeadingText()}
+      </div>
+    )
+
     return (
       <div className={cx.sidebar} style={{ width: `${sidebarWidth}px` }}>
-        {sidebarHeading && (
-          sidebarHeadingLink ? (
-            <a onClick={sidebarHeadingLink} className={[cx.sidebarHeading, cx.sidebarHeadingLink].join(' ')}>
-              {renderHeadingText()}
-            </a>
-          ) : (
-            <div className={cx.sidebarHeading}>
-              {renderHeadingText()}
-            </div>
-          )
-        )}
+        {sidebarHeading && (typeof sidebarHeading === 'string' ? renderHeadingTextComponent() : (
+          <div className={cx.sidebarHeading}>
+            {sidebarHeading}
+          </div>
+        )) }
         <div className={[cx.sidebarBody, scrollableSidebar ? cx.scrollableSidebar : cx.nonScrollableSidebar].join(' ')}>
           {sidebar}
         </div>

--- a/src/components/ui/TwoColumnsLayout.stories.js
+++ b/src/components/ui/TwoColumnsLayout.stories.js
@@ -7,6 +7,7 @@ import TwoColumnsLayout from './TwoColumnsLayout'
 import ProfileHeaderLinks from './ProfileHeaderLinks'
 import { StoryAdminScreen } from './AdminScreen.stories'
 import { StoryFilters } from './Filters/Filters.stories'
+import HeadingWithQuickSearch from './HeadingWithQuickSearch'
 import { getIcons } from './SvgIcon.js'
 
 const icons = getIcons()
@@ -29,9 +30,9 @@ export const StoryTwoColumnsLayout = (props) => (
   <TwoColumnsLayout
     sidebar={props.sidebar || sampleSidebar}
     sidebarHeading={text('Sidebar Heading', props.sidebarHeading || 'Filters')}
-    sidebarHeadingLink={text('Sidebar Heading Link', props.sidebarHeadingLink || '')}
+    sidebarHeadingAction={props.sidebarHeadingAction}
     sidebarWidth={number('Sidebar Width', props.sidebarWidth || 385)}
-    sidebarIcon={select('Sidebar Icon', availableIcons, props.sidebarIcon || 'filters')}
+    sidebarIcon={select('Sidebar Icon', availableIcons, props.sidebarIcon || '')}
     scrollableSidebar={boolean('Scrollable Sidebar', props.scrollableSidebar !== undefined ? props.scrollableSidebar : true)}
     content={props.content || sampleContent}
     contentHeading={text('Content Heading', props.contentHeading || 'Search')}
@@ -54,10 +55,11 @@ storiesOf('UI Components/TwoColumnsLayout/Use cases', module)
       </StoryAdminScreen>
     </Body>
   ))
-  .add('composed in AdminScreen with Filters', () => (
+  .add('composed in AdminScreen with Filters and sidebarHeading element', () => (
     <Body>
       <StoryAdminScreen>
         <StoryTwoColumnsLayout
+          sidebarHeading={<HeadingWithQuickSearch leftIcon='filters' text='Filters' />}
           sidebar={<StoryFilters />}
         />
       </StoryAdminScreen>
@@ -104,6 +106,22 @@ storiesOf('UI Components/TwoColumnsLayout/Debug', module)
       </StoryAdminScreen>
     </Body>
   ))
+  .add('with composed headings in AdminScreen', () => (
+    <Body>
+      <StoryAdminScreen>
+        <StoryTwoColumnsLayout
+          sidebarHeading={<div style={{ backgroundColor: 'black', color: 'white' }}>bump</div>}
+          contentHeading={<div style={{ backgroundColor: 'black', color: 'white' }}>bump</div>}
+        />
+      </StoryAdminScreen>
+    </Body>
+  ), {
+    notes: {
+      markdown: `
+This story is useful to demonstrate how both heading parts behave by default when being passed a Component, instead of a string.
+      `
+    }
+  })
   .add('composed in AdminScreen and with Modal with short content', () => (
     <Body>
       <StoryAdminScreen
@@ -122,7 +140,7 @@ storiesOf('UI Components/TwoColumnsLayout/Debug', module)
           sidebarIcon='arrowleft'
           sidebarWidth={425}
           sidebarHeading='A link in the sidebar heading'
-          sidebarHeadingLink={action('Sidebar heading route redirection')}
+          sidebarHeadingAction={action('Sidebar heading route redirection')}
           contentHeading={(
             <ProfileHeaderLinks
               smaller

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ import GenericCollapsible from './components/ui/GenericCollapsible'
 import GenericCopyToClipboard from './components/ui/GenericCopyToClipboard'
 import GenericTabs from './components/ui/GenericTabs'
 import HeaderBar from './components/ui/HeaderBar'
+import HeadingWithQuickSearch from './components/ui/HeadingWithQuickSearch'
 import HorizontalRuler from './components/ui/HorizontalRuler'
 import InlineEditor from './components/ui/InlineEditor'
 import InputField from './components/forms/InputField'
@@ -93,6 +94,7 @@ export {
   GenericCopyToClipboard,
   GenericTabs,
   HeaderBar,
+  HeadingWithQuickSearch,
   HorizontalRuler,
   InlineEditor,
   InputField,


### PR DESCRIPTION
**Release Type:** *Non-Breaking Feature*

Fixes https://x-team-internal.atlassian.net/browse/XP-3170

## Description

- Added the `data-testid` attribute in the view of some components to be able to add the E2E required by the A/C

## Checklist

- [x] set yourself as an assignee
- [x] set appropriate labels for a PR
- [x] make sure your code lints (`npm run lint`)
- [x] Flow typechecks passed (`npm run flow`)
- [x] Snapshots tests passed (`npm run jest`)
- [x] if any snapshots have been changed, verify that component still works and looks as expected and update the changed snapshot

## Related PRs

<!-- List related PRs against other XP repos if applicable: -->

branch | PR
------ | ------
XP-3170-e2e-switching-lists | [XP](https://github.com/x-team/xp/pull/1965)
XP-3171-switching-accepted-excluded | [XP](https://github.com/x-team/xp/pull/1966)
XP-3172-performing-filtering | [XP](https://github.com/x-team/xp/pull/1969)
XP-3173-updating-column-customizer | [XP](https://github.com/x-team/xp/pull/1971)
XP-3174-sorting-ordering | [XP](https://github.com/x-team/xp/pull/1970)
XP-3175-deleting-archiving | [XP](https://github.com/x-team/xp/pull/1972)
XP-3176-applicant-profile-view | [XP](https://github.com/x-team/xp/pull/1967)

## Impacted Areas in Application

- ApplicantBadge
- Button
- DataGrid
- HeadingWithQuickSearch
- Filters.Filter
- Filters.Group
- Filters.Label
- Filters.TabButton
- Filters.Heading
- ListsEditor
- QuickSearchButton