### PR TITLE
Add data-testid attribute needed for the E2E tests in the Search Page for the switching lists cases

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -464,7 +464,7 @@ exports[`Storyshots Form Components/SolutionForm 2 attempts are taken 1`] = `
       color="normal"
       component="button"
       contentStyle="normal"
-      data-test="solutionSubmit"
+      data-testid="xpui-solutionForm-button-submit"
       disabled={false}
       icon=""
       iconProps={Object {}}
@@ -508,7 +508,7 @@ exports[`Storyshots Form Components/SolutionForm custom submit callback is passe
       color="normal"
       component="button"
       contentStyle="normal"
-      data-test="solutionSubmit"
+      data-testid="xpui-solutionForm-button-submit"
       disabled={false}
       icon=""
       iconProps={Object {}}
@@ -551,7 +551,7 @@ exports[`Storyshots Form Components/SolutionForm max of 5 attempts allowed 1`] =
       color="normal"
       component="button"
       contentStyle="normal"
-      data-test="solutionSubmit"
+      data-testid="xpui-solutionForm-button-submit"
       disabled={false}
       icon=""
       iconProps={Object {}}
@@ -594,7 +594,7 @@ exports[`Storyshots Form Components/SolutionForm missing props (does component e
       color="normal"
       component="button"
       contentStyle="normal"
-      data-test="solutionSubmit"
+      data-testid="xpui-solutionForm-button-submit"
       disabled={false}
       icon=""
       iconProps={Object {}}
@@ -637,7 +637,7 @@ exports[`Storyshots Form Components/SolutionForm submitting is in progress 1`] =
       color="normal"
       component="button"
       contentStyle="normal"
-      data-test="solutionSubmit"
+      data-testid="xpui-solutionForm-button-submit"
       disabled={true}
       icon=""
       iconProps={Object {}}
@@ -680,7 +680,7 @@ exports[`Storyshots Form Components/SolutionForm with disabled button 1`] = `
       color="normal"
       component="button"
       contentStyle="normal"
-      data-test="solutionSubmit"
+      data-testid="xpui-solutionForm-button-submit"
       disabled={true}
       icon=""
       iconProps={Object {}}
@@ -2944,7 +2944,7 @@ exports[`Storyshots UI Components/ApplicantBadge/Debug missing props (does compo
 exports[`Storyshots UI Components/ApplicantGrid basic usage 1`] = `
 <div
   className="AutoUI_ui_ApplicantGrid-11"
-  data-test="applicants"
+  data-testid="xpui-applicantGrid"
   onKeyPress={[Function]}
   tabIndex={0}
 >
@@ -3043,7 +3043,7 @@ exports[`Storyshots UI Components/ApplicantGrid basic usage 1`] = `
 exports[`Storyshots UI Components/ApplicantGrid/Debug missing props (does component explode?) 1`] = `
 <div
   className="AutoUI_ui_ApplicantGrid-11"
-  data-test="applicants"
+  data-testid="xpui-applicantGrid"
   onKeyPress={[Function]}
   tabIndex={0}
 >
@@ -4590,7 +4590,9 @@ exports[`Storyshots UI Components/Button/With Knobs all effects 1`] = `
 <button
   className="    "
 >
-  <span>
+  <span
+    data-testid="xpui-button"
+  >
     This is a button
   </span>
 </button>
@@ -15755,9 +15757,11 @@ exports[`Storyshots UI Components/DataGrid loading 1`] = `
 exports[`Storyshots UI Components/DataGrid/Debug missing props (does component explode?) 1`] = `
 <div
   className="AutoUI_ui_DataGrid-45"
+  data-testid="xpui-dataGrid-container"
 >
   <div
     className="AutoUI_ui_DataGrid-51"
+    data-testid="xpui-dataGrid-grid"
   >
     <ReactDataGrid
       cellNavigationMode="none"
@@ -15811,7 +15815,7 @@ exports[`Storyshots UI Components/Dropdown SelectBox example 1`] = `
 >
   <div
     className="AutoUI_ui_Dropdown-24 AutoUI_ui_Dropdown-44"
-    data-testid="xpui-dropdown__button"
+    data-testid="xpui-dropdown-button"
     onClick={[Function]}
   >
     <SvgIcon
@@ -15820,7 +15824,7 @@ exports[`Storyshots UI Components/Dropdown SelectBox example 1`] = `
     />
     <span
       className="AutoUI_ui_Dropdown-40"
-      data-testid="xpui-dropdown__button__label"
+      data-testid="xpui-dropdown-button-label"
     >
       This is a Dropdown
     </span>
@@ -15835,7 +15839,7 @@ exports[`Storyshots UI Components/Dropdown SelectBox example 1`] = `
   </div>
   <div
     className="AutoUI_ui_Dropdown-50     "
-    data-testid="xpui-dropdown__children"
+    data-testid="xpui-dropdown-children"
   >
     <SelectBox
       areItemsToggleable={true}
@@ -15895,12 +15899,12 @@ exports[`Storyshots UI Components/Dropdown SelectBox example using radio buttons
 >
   <div
     className="AutoUI_ui_Dropdown-24 AutoUI_ui_Dropdown-44"
-    data-testid="xpui-dropdown__button"
+    data-testid="xpui-dropdown-button"
     onClick={[Function]}
   >
     <span
       className="AutoUI_ui_Dropdown-40"
-      data-testid="xpui-dropdown__button__label"
+      data-testid="xpui-dropdown-button-label"
     >
       registered
     </span>
@@ -15915,7 +15919,7 @@ exports[`Storyshots UI Components/Dropdown SelectBox example using radio buttons
   </div>
   <div
     className="AutoUI_ui_Dropdown-50     "
-    data-testid="xpui-dropdown__children"
+    data-testid="xpui-dropdown-children"
   >
     <SelectBox
       areItemsToggleable={true}
@@ -15975,12 +15979,12 @@ exports[`Storyshots UI Components/Dropdown close Dropdown from children 1`] = `
 >
   <div
     className="AutoUI_ui_Dropdown-24 "
-    data-testid="xpui-dropdown__button"
+    data-testid="xpui-dropdown-button"
     onClick={[Function]}
   >
     <span
       className="AutoUI_ui_Dropdown-40"
-      data-testid="xpui-dropdown__button__label"
+      data-testid="xpui-dropdown-button-label"
     >
       <h1>
         Click to open!
@@ -15989,11 +15993,11 @@ exports[`Storyshots UI Components/Dropdown close Dropdown from children 1`] = `
   </div>
   <div
     className="AutoUI_ui_Dropdown-50    AutoUI_ui_Dropdown-111 "
-    data-testid="xpui-dropdown__children"
+    data-testid="xpui-dropdown-children"
   >
     <div
       className="AutoUI_ui_Dropdown-71 "
-      data-testid="xpui-dropdown__children__tooltip"
+      data-testid="xpui-dropdown-children-tooltip"
     >
       <CloseButton
         closeDropdown={[Function]}
@@ -16011,7 +16015,7 @@ exports[`Storyshots UI Components/Dropdown icon only button 1`] = `
 >
   <div
     className="AutoUI_ui_Dropdown-24 AutoUI_ui_Dropdown-44"
-    data-testid="xpui-dropdown__button"
+    data-testid="xpui-dropdown-button"
     onClick={[Function]}
   >
     <SvgIcon
@@ -16021,7 +16025,7 @@ exports[`Storyshots UI Components/Dropdown icon only button 1`] = `
   </div>
   <div
     className="AutoUI_ui_Dropdown-50     "
-    data-testid="xpui-dropdown__children"
+    data-testid="xpui-dropdown-children"
   >
     <div
       key=".0"
@@ -16111,7 +16115,7 @@ exports[`Storyshots UI Components/Dropdown labeled button 1`] = `
 >
   <div
     className="AutoUI_ui_Dropdown-24 "
-    data-testid="xpui-dropdown__button"
+    data-testid="xpui-dropdown-button"
     onClick={[Function]}
   >
     <SvgIcon
@@ -16120,7 +16124,7 @@ exports[`Storyshots UI Components/Dropdown labeled button 1`] = `
     />
     <span
       className="AutoUI_ui_Dropdown-40"
-      data-testid="xpui-dropdown__button__label"
+      data-testid="xpui-dropdown-button-label"
     >
       Add to List
     </span>
@@ -16135,7 +16139,7 @@ exports[`Storyshots UI Components/Dropdown labeled button 1`] = `
   </div>
   <div
     className="AutoUI_ui_Dropdown-50     "
-    data-testid="xpui-dropdown__children"
+    data-testid="xpui-dropdown-children"
   >
     <div
       key=".0"
@@ -16200,12 +16204,12 @@ exports[`Storyshots UI Components/Dropdown tooltip display 1`] = `
 >
   <div
     className="AutoUI_ui_Dropdown-24 "
-    data-testid="xpui-dropdown__button"
+    data-testid="xpui-dropdown-button"
     onClick={[Function]}
   >
     <span
       className="AutoUI_ui_Dropdown-40"
-      data-testid="xpui-dropdown__button__label"
+      data-testid="xpui-dropdown-button-label"
     >
       <Button
         block={false}
@@ -16233,11 +16237,11 @@ exports[`Storyshots UI Components/Dropdown tooltip display 1`] = `
   </div>
   <div
     className="AutoUI_ui_Dropdown-50    AutoUI_ui_Dropdown-111 "
-    data-testid="xpui-dropdown__children"
+    data-testid="xpui-dropdown-children"
   >
     <div
       className="AutoUI_ui_Dropdown-71 "
-      data-testid="xpui-dropdown__children__tooltip"
+      data-testid="xpui-dropdown-children-tooltip"
     >
       Anything here
     </div>
@@ -20517,6 +20521,7 @@ exports[`Storyshots UI Components/Filters/Debug missing props for Filter (does c
   <Label />
   <div
     className="AutoUI_ui_Filters_Filter-17"
+    data-testid="xpui-filters-filter"
   />
 </Fragment>
 `;
@@ -20524,6 +20529,7 @@ exports[`Storyshots UI Components/Filters/Debug missing props for Filter (does c
 exports[`Storyshots UI Components/Filters/Debug missing props for Group (does components explode?) 1`] = `
 <div
   className="AutoUI_ui_Filters_Group-17"
+  data-testid="xpui-filters-group"
 />
 `;
 
@@ -20533,9 +20539,11 @@ exports[`Storyshots UI Components/Filters/Debug missing props for Heading (does 
 >
   <div
     className="AutoUI_ui_Filters_Heading-51"
+    data-testid="xpui-filters-heading-children"
   />
   <div
     className="AutoUI_ui_Filters_Heading-55"
+    data-testid="xpui-filters-heading-arrow"
   >
     <SvgIcon
       color="grayscarpaflow"
@@ -20548,6 +20556,7 @@ exports[`Storyshots UI Components/Filters/Debug missing props for Heading (does 
 exports[`Storyshots UI Components/Filters/Debug missing props for Label (does components explode?) 1`] = `
 <div
   className="AutoUI_ui_Filters_Label-17 AutoUI_typo-34"
+  data-testid="xpui-filters-label"
 />
 `;
 
@@ -20568,6 +20577,7 @@ exports[`Storyshots UI Components/Filters/Debug missing props for TabButton (doe
   color="silver"
   component="button"
   contentStyle="normal"
+  data-testid="xpui-filters-tabButton"
   disabled={false}
   icon=""
   iconProps={Object {}}
@@ -22153,6 +22163,7 @@ exports[`Storyshots UI Components/HeadingWithQuickSearch self-controlled sidebar
 exports[`Storyshots UI Components/HeadingWithQuickSearch/Debug missing props (does component explode?) 1`] = `
 <div
   className="AutoUI_ui_HeadingWithQuickSearch-18 AutoUI_typo-22"
+  data-testid="xpui-headingWithQuickSearch-container"
 >
   <QuickSearchButton
     onClick={[Function]}
@@ -22182,6 +22193,7 @@ exports[`Storyshots UI Components/HeadingWithQuickSearch/Debug with action handl
 exports[`Storyshots UI Components/HeadingWithQuickSearch/Debug without wrapper 1`] = `
 <div
   className="AutoUI_ui_HeadingWithQuickSearch-18 AutoUI_typo-22"
+  data-testid="xpui-headingWithQuickSearch-container"
 >
   <div
     className="AutoUI_ui_HeadingWithQuickSearch-30"
@@ -22421,7 +22433,7 @@ exports[`Storyshots UI Components/ListExclusionFormPopup/Debug missing props (do
       className="AutoUI_ui_ListExclusionFormPopup-52"
     >
       <InputField
-        data-testid="exclusion-comment"
+        data-testid="xpui-listExclusionFormPopup-input-comment"
         isInvalid={false}
         label="Add a comment"
         name="reason"
@@ -22441,7 +22453,7 @@ exports[`Storyshots UI Components/ListExclusionFormPopup/Debug missing props (do
           color="normal"
           component="button"
           contentStyle="normal"
-          data-testid="exclusion-cancel"
+          data-testid="xpui-listExclusionFormPopup-button-cancel"
           disabled={false}
           icon=""
           iconProps={Object {}}
@@ -22465,7 +22477,7 @@ exports[`Storyshots UI Components/ListExclusionFormPopup/Debug missing props (do
           color="normal"
           component="button"
           contentStyle="normal"
-          data-testid="exclusion-submit"
+          data-testid="xpui-listExclusionFormPopup-button-submit"
           disabled={true}
           icon=""
           iconProps={Object {}}
@@ -22635,6 +22647,7 @@ exports[`Storyshots UI Components/ListsEditor basic 1`] = `
 exports[`Storyshots UI Components/ListsEditor missing props (does component explode?) 1`] = `
 <div
   className="AutoUI_ui_ListsEditor-53"
+  data-testid="xpui-listsEditor"
 >
   <h1
     className="AutoUI_ui_ListsEditor-59 AutoUI_typo-105 AutoUI_typo-53 AutoUI_typo-34"
@@ -22851,15 +22864,15 @@ exports[`Storyshots UI Components/MetaGroup standalone composed with children 1`
 exports[`Storyshots UI Components/MetaGroup/Debug missing props (does component explode?) 1`] = `
 <div
   className="AutoUI_ui_MetaGroup-10"
-  data-testid="xpui-metaGroup__layout"
+  data-testid="xpui-metaGroup-layout"
 >
   <div
     className="AutoUI_ui_MetaGroup-15"
-    data-testid="xpui-metaGroup__mainBodyColumn"
+    data-testid="xpui-metaGroup-mainBodyColumn"
   />
   <div
     className="AutoUI_ui_MetaGroup-21"
-    data-testid="xpui-metaGroup__secondaryColumns"
+    data-testid="xpui-metaGroup-secondaryColumns"
   />
 </div>
 `;
@@ -25595,6 +25608,7 @@ exports[`Storyshots UI Components/QuickSearchButton basic usage 1`] = `
 exports[`Storyshots UI Components/QuickSearchButton/Debug missing props (does component explode?) 1`] = `
 <div
   className="AutoUI_ui_QuickSearchButton-15"
+  data-testid="xpui-quickSearchButton"
   onClick={[Function]}
 >
   <SvgIcon
@@ -26118,7 +26132,7 @@ exports[`Storyshots UI Components/RoadmapLevel centered state with CTA button 1`
     color="normal"
     component="button"
     contentStyle="normal"
-    data-test="roadmapStart"
+    data-testid="xpui-roadmapLevel-button-cta"
     disabled={false}
     icon=""
     iconProps={Object {}}

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -20536,6 +20536,7 @@ exports[`Storyshots UI Components/Filters/Debug missing props for Group (does co
 exports[`Storyshots UI Components/Filters/Debug missing props for Heading (does components explode?) 1`] = `
 <div
   className="AutoUI_ui_Filters_Heading-22 AutoUI_typo-22 AutoUI_ui_Filters_Heading-45"
+  data-testid="xpui-filters-heading"
 >
   <div
     className="AutoUI_ui_Filters_Heading-51"

--- a/src/components/forms/SolutionForm/index.js
+++ b/src/components/forms/SolutionForm/index.js
@@ -111,7 +111,7 @@ class SolutionForm extends PureComponent<Props> {
           onChange: onValueChange,
           placeholder: 'Paste your solution here.'
         }),
-        <Button disabled={isSubmitting || disableButton} data-test='solutionSubmit'>
+        <Button disabled={isSubmitting || disableButton} data-testid='xpui-solutionForm-button-submit'>
           {isSubmitting ? 'Checking...' : `Submit (${takenAttempts + 1} of ${maxAttempts})`}
         </Button>
       )

--- a/src/components/ui/ApplicantBadge.js
+++ b/src/components/ui/ApplicantBadge.js
@@ -452,7 +452,7 @@ class ApplicantBadge extends PureComponent<Props> {
           <div className={cx.nameInner} title={name || email}>{name || email}</div>
           {this.renderStatusIndicator()}
         </div>
-        <div className={cx.avatar}>
+        <div className={cx.avatar} data-testid='xpui-applicantBadge-avatar'>
           {avatar || (
             <Avatar
               src={`https://www.gravatar.com/avatar/${md5(email)}?s=65`}
@@ -461,20 +461,20 @@ class ApplicantBadge extends PureComponent<Props> {
             />
           )}
         </div>
-        <div className={cx.controls}>
+        <div className={cx.controls} data-testid='xpui-applicantBadge-controls'>
           {this.renderActions()}
         </div>
-        <div className={cx.infos}>
+        <div className={cx.infos} data-testid='xpui-applicantBadge-infos'>
           {this.mapInfosToRender()}
         </div>
-        <div className={cx.applicantStatus}>
+        <div className={cx.applicantStatus} data-testid='xpui-applicantBadge-applicantStatus'>
           {applicantStatus}
         </div>
-        <div className={cx.tags}>
+        <div className={cx.tags} data-testid='xpui-applicantBadge-tags'>
           {this.mapTagsToRender()}
         </div>
         {children && (
-          <div className={cx.children}>
+          <div className={cx.children} data-testid='xpui-applicantBadge-children'>
             {children}
           </div>
         )}

--- a/src/components/ui/ApplicantBadge.js
+++ b/src/components/ui/ApplicantBadge.js
@@ -447,9 +447,9 @@ class ApplicantBadge extends PureComponent<Props> {
     const { id, active, name, email, avatar, children, applicantStatus } = this.props
 
     return id ? (
-      <div onClick={this.handleBadgeClick} className={[cx.wrapper, cx.displayControlsOnHover, active ? cx.active : ''].join(' ')}>
-        <div className={cx.name}>
-          <div className={cx.nameInner} title={name || email}>{name || email}</div>
+      <div onClick={this.handleBadgeClick} className={[cx.wrapper, cx.displayControlsOnHover, active ? cx.active : ''].join(' ')} data-testid='xpui-applicantBadge-container'>
+        <div className={cx.name} data-testid='xpui-applicantBadge-name'>
+          <div className={cx.nameInner} title={name || email} data-testid='xpui-applicantBadge-name-inner'>{name || email}</div>
           {this.renderStatusIndicator()}
         </div>
         <div className={cx.avatar} data-testid='xpui-applicantBadge-avatar'>

--- a/src/components/ui/ApplicantGrid.js
+++ b/src/components/ui/ApplicantGrid.js
@@ -87,7 +87,7 @@ class ApplicantGrid extends PureComponent<Props, State> {
     return items && (
       <div
         className={cx.wrapper}
-        data-test='applicants'
+        data-testid='xpui-applicantGrid'
         tabIndex={0}
         onKeyPress={this.handleKeyPress}
       >

--- a/src/components/ui/Button.js
+++ b/src/components/ui/Button.js
@@ -446,7 +446,7 @@ class Button extends PureComponent<Props> {
         data-tag={tag}
       >
         {icon && <SvgIcon className={baseStyles.icon} icon={icon} color='' {...iconProps} />}
-        <span>{children}</span>
+        <span data-testid='xpui-button'>{children}</span>
       </CustomComponent>
     )
   }

--- a/src/components/ui/DataGrid.js
+++ b/src/components/ui/DataGrid.js
@@ -94,8 +94,8 @@ const DataGrid = ({
   rowsCount
 }: Props) =>
   (
-    <div className={cx.gridContainer}>
-      <div className={cx.grid}>
+    <div className={cx.gridContainer} data-testid='xpui-dataGrid-container'>
+      <div className={cx.grid} data-testid='xpui-dataGrid-grid'>
         {isLoading && (
           <div className={cx.overlay}>
             <Loader />

--- a/src/components/ui/Dropdown.js
+++ b/src/components/ui/Dropdown.js
@@ -219,10 +219,10 @@ class Dropdown extends PureComponent<Props, State> {
         onMouseLeave={hover ? this.close : undefined}
         data-testid='xpui-dropdown'
       >
-        <div className={labelClasses} onClick={handleClick} data-testid='xpui-dropdown__button'>
+        <div className={labelClasses} onClick={handleClick} data-testid='xpui-dropdown-button'>
           {icon && <SvgIcon icon={icon} color={iconColor} />}
           {label && (
-            <span className={styles.labelElement} data-testid='xpui-dropdown__button__label'>
+            <span className={styles.labelElement} data-testid='xpui-dropdown-button-label'>
               {label}
             </span>
           )}
@@ -233,9 +233,9 @@ class Dropdown extends PureComponent<Props, State> {
           )}
         </div>
         {children && (
-          <div className={contentClasses} data-testid='xpui-dropdown__children'>
+          <div className={contentClasses} data-testid='xpui-dropdown-children'>
             {tooltip ? (
-              <div className={tooltipClasses} data-testid='xpui-dropdown__children__tooltip'>
+              <div className={tooltipClasses} data-testid='xpui-dropdown-children-tooltip'>
                 {dropdownChildren()}
               </div>
             ) : (

--- a/src/components/ui/Filters/Filter.js
+++ b/src/components/ui/Filters/Filter.js
@@ -23,7 +23,7 @@ const cx = {
 const Filter = (props: Props) => (
   <Fragment>
     <Label>{props.label}</Label>
-    <div className={cx.filter}>{props.children}</div>
+    <div className={cx.filter} data-testid='xpui-filters-filter'>{props.children}</div>
   </Fragment>
 )
 

--- a/src/components/ui/Filters/Group.js
+++ b/src/components/ui/Filters/Group.js
@@ -41,7 +41,7 @@ const cx = {
 }
 
 const Group = (props: Props) => (
-  <div className={props.isCentered ? [cx.group, cx.centered].join(' ') : cx.group}>
+  <div className={props.isCentered ? [cx.group, cx.centered].join(' ') : cx.group} data-testid='xpui-filters-group'>
     {props.children}
   </div>
 )

--- a/src/components/ui/Filters/Heading.js
+++ b/src/components/ui/Filters/Heading.js
@@ -58,7 +58,8 @@ const cx = {
 }
 
 const Heading = (props: Props) => (
-  <div onClick={props.onClick} className={props.isExpanded ? cx.heading : `${cx.heading} ${cx.headingCollapsed}`}>
+  <div onClick={props.onClick} className={props.isExpanded ? cx.heading : `${cx.heading} ${cx.headingCollapsed}`}
+    data-testid='xpui-filters-heading'>
     <div className={cx.text} data-testid='xpui-filters-heading-children'>
       {props.children}
     </div>

--- a/src/components/ui/Filters/Heading.js
+++ b/src/components/ui/Filters/Heading.js
@@ -59,11 +59,11 @@ const cx = {
 
 const Heading = (props: Props) => (
   <div onClick={props.onClick} className={props.isExpanded ? cx.heading : `${cx.heading} ${cx.headingCollapsed}`}>
-    <div className={cx.text}>
+    <div className={cx.text} data-testid='xpui-filters-heading-children'>
       {props.children}
     </div>
     {props.extra}
-    <div className={cx.arrow}>
+    <div className={cx.arrow} data-testid='xpui-filters-heading-arrow'>
       <SvgIcon
         icon={props.isExpanded ? 'triangleup' : 'triangledown'}
         color='grayscarpaflow'

--- a/src/components/ui/Filters/Label.js
+++ b/src/components/ui/Filters/Label.js
@@ -25,6 +25,6 @@ const cx = {
   `)
 }
 
-const Label = (props: Props) => <div className={cx.label}>{props.children}</div>
+const Label = (props: Props) => <div className={cx.label} data-testid='xpui-filters-label'>{props.children}</div>
 
 export default Label

--- a/src/components/ui/Filters/TabButton.js
+++ b/src/components/ui/Filters/TabButton.js
@@ -53,6 +53,7 @@ const TabButton = (props: Props) => (
     smallRounded
     onClick={props.onClick}
     className={props.isActive ? `${cx.button} ${cx.active}` : cx.button}
+    data-testid='xpui-filters-tabButton'
   >
     {props.text}
   </Button>

--- a/src/components/ui/HeadingWithQuickSearch.js
+++ b/src/components/ui/HeadingWithQuickSearch.js
@@ -165,15 +165,16 @@ class HeadingWithQuickSearch extends PureComponent<Props, State> {
     const isQuickSearchActive = isQuickSearching || this.state.isSearching
 
     return isQuickSearchActive ? (
-      <div className={[cx.container, cx.inputContainer].join(' ')}>
+      <div className={[cx.container, cx.inputContainer].join(' ')} data-testid='xpui-headingWithQuickSearch-container'>
         {this.renderLeftIcon('magnifier')}
         {this.renderInput()}
-        <div className={cx.sidebarHeadingIconRight} onClick={this.handleToggleQuickSearch(false)} >
+        <div className={cx.sidebarHeadingIconRight} onClick={this.handleToggleQuickSearch(false)}
+          data-testid='xpui-headingWithQuickSearch-iconRight-button'>
           <SvgIcon icon={'x'} color='grayscarpaflow' />
         </div>
       </div>
     ) : (
-      <div className={cx.container}>
+      <div className={cx.container} data-testid='xpui-headingWithQuickSearch-container'>
         {this.renderLeftIcon(leftIcon, headingAction)}
         {this.renderHeadingText(text, headingAction)}
         <QuickSearchButton onClick={this.handleToggleQuickSearch(true)} />

--- a/src/components/ui/ListExclusionFormPopup.js
+++ b/src/components/ui/ListExclusionFormPopup.js
@@ -293,7 +293,7 @@ class ListExclusionFormPopup extends PureComponent<Props, State> {
           {applicant && <h1 className={cx.applicant}>{applicant}</h1>}
           <div className={cx.container}>
             {reasons.map((value, index) => (
-              <div className={cx.input} key={index} data-testid='exclusion-reasons'>
+              <div className={cx.input} key={index} data-testid='xpui-listExclusionFormPopup-input-reasons'>
                 <InputField
                   name='reasons'
                   type='radio'
@@ -311,13 +311,13 @@ class ListExclusionFormPopup extends PureComponent<Props, State> {
               placeholder='Provide a reason'
               value={reasonLabel}
               onChange={this.handleCommentChange}
-              data-testid='exclusion-comment'
+              data-testid='xpui-listExclusionFormPopup-input-comment'
             />
             <div className={cx.buttons}>
-              <Button pseudolink onClick={this.handleCancel} data-testid='exclusion-cancel'>
+              <Button pseudolink onClick={this.handleCancel} data-testid='xpui-listExclusionFormPopup-button-cancel'>
                 Cancel
               </Button>
-              <Button onClick={this.handleSubmit} data-testid='exclusion-submit' disabled={reasonLabel === ''}>
+              <Button onClick={this.handleSubmit} data-testid='xpui-listExclusionFormPopup-button-submit' disabled={reasonLabel === ''}>
                 <SvgIcon icon='paperplane' color='inverted' />
               </Button>
             </div>

--- a/src/components/ui/ListsEditor.js
+++ b/src/components/ui/ListsEditor.js
@@ -333,7 +333,7 @@ class ListsEditor extends Component<Props, State> {
     const { title } = this.props
 
     return (
-      <div className={cx.listseditor}>
+      <div className={cx.listseditor} data-testid='xpui-listsEditor'>
         <h1 className={cx.heading}>Edit {title}</h1>
         <Tabs className={cx.tabs}>
           <Tab title='Active'>

--- a/src/components/ui/MetaGroup.js
+++ b/src/components/ui/MetaGroup.js
@@ -46,13 +46,13 @@ class MetaGroup extends PureComponent<Props, void> {
   render () {
     const { mainBodyElement, secondaryElements } = this.props
     return (
-      <div className={cx.layout} data-testid='xpui-metaGroup__layout'>
-        <div className={cx.mainBodyColumn} data-testid='xpui-metaGroup__mainBodyColumn'>
+      <div className={cx.layout} data-testid='xpui-metaGroup-layout'>
+        <div className={cx.mainBodyColumn} data-testid='xpui-metaGroup-mainBodyColumn'>
           {mainBodyElement}
         </div>
-        <div className={cx.secondaryColumns} data-testid='xpui-metaGroup__secondaryColumns'>
+        <div className={cx.secondaryColumns} data-testid='xpui-metaGroup-secondaryColumns'>
           {secondaryElements.map(element => (
-            <div className={cx.secondaryColumn} key={element.key} data-testid='xpui-metaGroup__secondaryColumn'>
+            <div className={cx.secondaryColumn} key={element.key} data-testid='xpui-metaGroup-secondaryColumns-column'>
               {element}
             </div>
           ))}

--- a/src/components/ui/QuickSearchButton.js
+++ b/src/components/ui/QuickSearchButton.js
@@ -34,7 +34,7 @@ const container = cmz(`
 `)
 
 const QuickSearchButton = ({ onClick }: Props) => (
-  <div className={container} onClick={onClick}>
+  <div className={container} onClick={onClick} data-testid='xpui-quickSearchButton'>
     <SvgIcon color='grayscarpaflow' icon='magnifier' hover='default' />
   </div>
 )

--- a/src/components/ui/RoadmapLevel.js
+++ b/src/components/ui/RoadmapLevel.js
@@ -70,7 +70,7 @@ class RoadmapLevel extends PureComponent<Props> {
       return null
     }
 
-    const buttonCTA = cta.label && <Button className={ctaButtonStyles} block onClick={cta.handle} data-test='roadmapStart'>{cta.label}</Button>
+    const buttonCTA = cta.label && <Button className={ctaButtonStyles} block onClick={cta.handle} data-testid='xpui-roadmapLevel-button-cta'>{cta.label}</Button>
     const levelLabel = level ? `Level ${level}` : ''
 
     return Root(


### PR DESCRIPTION
**Release Type:** *Non-Breaking Feature*

Fixes https://x-team-internal.atlassian.net/browse/XP-3170

## Description

- Added the `data-testid` attribute in the view of some components to be able to add the E2E required by the A/C
- https://github.com/x-team/xp-ui/pull/423 (CLOSED). The PR#423 was closed due to the high number of changes required to restore back the code style in this comment https://github.com/x-team/xp-ui/pull/423#issuecomment-520496017. This current PR has the same changes as the PR#423 but respecting the code style of the project

## Checklist

- [x] set yourself as an assignee
- [x] set appropriate labels for a PR
- [x] make sure your code lints (`npm run lint`)
- [x] Flow typechecks passed (`npm run flow`)
- [x] Snapshots tests passed (`npm run jest`)
- [x] if any snapshots have been changed, verify that component still works and looks as expected and update the changed snapshot

## Related PRs

branch | PR
------ | ------
XP-3170-e2e-switching-lists | [XP](https://github.com/x-team/xp/pull/1965)
XP-3171-switching-accepted-excluded | [XP](https://github.com/x-team/xp/pull/1966)
XP-3172-performing-filtering | [XP](https://github.com/x-team/xp/pull/1969)
XP-3173-updating-column-customizer | [XP](https://github.com/x-team/xp/pull/1971)
XP-3174-sorting-ordering | [XP](https://github.com/x-team/xp/pull/1970)
XP-3175-deleting-archiving | [XP](https://github.com/x-team/xp/pull/1972)
XP-3176-applicant-profile-view | [XP](https://github.com/x-team/xp/pull/1967)

## Impacted Areas in Application

- SolutionForm
- ApplicantBadge
- ApplicantGrid
- Button
- DataGrid
- Dropdown
- Filters/Filter
- Filters/Group
- Filters/Heading
- Filters/Label
- Filters/TabButton
- HeadingWithQuickSearch
- ListExclusionFormPopup
- ListsEditor
- MetaGroup
- QuickSearchButton
- RoadmapLevel