### PR TITLE
Expose HEX value at ColorPalette

### DIFF
--- a/src/components/styleguides/ColorPalette.js
+++ b/src/components/styleguides/ColorPalette.js
@@ -61,6 +61,7 @@ const cx = {
       width: 100%
       height: 90px
       border-radius: 2px
+      position: relative
     `
   ),
 
@@ -69,6 +70,19 @@ const cx = {
     padding: 4px 2px
     text-align: center
     border-radius: 0 0 2px 2px
+  `),
+
+  colorHex: cmz(`
+    display: block
+    position: absolute
+    top: 0
+    right: 0
+    font-size: .6em
+    background-color: ${theme.baseBrighter}
+    padding: 2px 4px
+    line-height: 1
+    border-radius: 0 2px 0 2px
+    text-transform: uppercase
   `)
 }
 
@@ -86,9 +100,8 @@ class ColorPalette extends PureComponent<Props> {
   renderColor = (name: string, set: string) => (
     <GenericCopyToClipboard text={name} key={`${set}-${name}`}>
       <div className={cx.color} style={{ backgroundColor: COLOR_SETS[set][name] }}>
-        <div className={cx.colorName}>
-          {name}
-        </div>
+        <div className={cx.colorName}>{name}</div>
+        <div className={cx.colorHex}>{COLOR_SETS[set][name]}</div>
       </div>
     </GenericCopyToClipboard>
   )


### PR DESCRIPTION
**Release Type:** *Dev improvements*

Fixes https://github.com/x-team/xp/issues/1994

## Description

Expose HEX value at ColorPalette to help identify very similar shades.

## Checklist

- [x] set yourself as an assignee
- [x] set appropriate labels for a PR (`In Review` or `In Progress` depending on its status)
- [x] make sure your code lints (`npm run lint`)
- [x] Flow typechecks passed (`npm run flow`)
- [x] Snapshots tests passed (`npm run jest`)
- [x] check cleanup tasks (https://github.com/x-team/xp/labels/cleanup) and take a suitable small one (if exists) in a related area of the current changes
- [x] **manually tested the app** by running it in several different browsers (Firefox, Chrome, Opera, Safari, MS IE/Edge, etc.) and checked nothing is broken and operates as expected!

## Steps to Test or Reproduce

1. Go to http://localhost:9001/?path=/story/styleguides--colorpalette
1. Observe that the HEX values are now exposed above the color blocks

## Impacted Areas in Application

- `ColorPalette`

## Screenshots

<img width="976" alt="Screen Shot 2019-09-10 at 11 13 05" src="https://user-images.githubusercontent.com/131859/64715622-37a19f80-d497-11e9-84a0-01cc1bf8777a.png">

