### PR TITLE
Publish `xp-ui` to NPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ npm-debug.log
 # production
 /lib
 .storybook-static
-lib

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ npm-debug.log
 # production
 /lib
 .storybook-static
+lib

--- a/README.md
+++ b/README.md
@@ -16,6 +16,31 @@ You need to install:
 - `npm install`
 - `npm start`
 
+## Deploy
+
+It's important to follow these steps with every update to `xp-ui` that we want to deploy. After release branch is merged into `master` branch of `xp-ui` (once the Production release initiation was confirmed), check out `master` branch and run a sequence of commands:
+
+```sh
+npm run release-[patch|minor|major]
+git push && git push --tags
+npm publish --access public
+```
+
+Additionally, we should ensure deploying recent `develop` changes tagged slightly different. For that, once we rebased that onto `master` (it's part of the [Production release process](https://x-team-internal.atlassian.net/wiki/spaces/XD/pages/340426777/To+Production)), update the `version` field of `package.json` to read `[MASTER_VERSION]-dev` and then run the following commands:
+
+```sh
+git push && git push --tags
+npm publish --access public
+```
+
+### Versioning
+
+Available commands are:
+
+- `npm run release-patch`: minor bug fixes, extra documentation, etc. Does not add any new functionality.
+- `npm run release-minor`: new functionality & features
+- `npm run release-major`: backwards-incompatible changes, like if there is a significant rewrite / refactor.
+
 ## Live preview
 
 - The latest Storybook spec page built out of `master` branch is available for preview [here](https://x-team.github.io/xp-ui/)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ git push && git push --tags
 npm publish --access public
 ```
 
-Additionally, we should ensure deploying recent `develop` changes tagged slightly different. For that, once we rebased that onto `master` (it's part of the [Production release process](https://x-team-internal.atlassian.net/wiki/spaces/XD/pages/340426777/To+Production)), update the `version` field of `package.json` to read `[MASTER_VERSION]-dev` and then run the following commands:
+Additionally, we should ensure publishing recent state of `develop` branch under a different version. For this, after rebasing onto `master` (as part of the [Production release process](https://x-team-internal.atlassian.net/wiki/spaces/XD/pages/340426777/To+Production)), update the `version` field of `package.json` to read `[MASTER_VERSION]-dev` (where `[MASTER_VERSION]` is the latest `version` value on the `master branch`) and then run the following commands:
 
 ```sh
 git add .

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ npm publish --access public
 Additionally, we should ensure deploying recent `develop` changes tagged slightly different. For that, once we rebased that onto `master` (it's part of the [Production release process](https://x-team-internal.atlassian.net/wiki/spaces/XD/pages/340426777/To+Production)), update the `version` field of `package.json` to read `[MASTER_VERSION]-dev` and then run the following commands:
 
 ```sh
+git add .
+git commit -m "Dev version deploy"
 git push && git push --tags
 npm publish --access public
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xp-ui",
-  "version": "2.0.0",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xp-ui",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x-team/xp-ui",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "UI component library for the XP platform.",
   "main": "lib/all.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x-team/xp-ui",
-  "version": "0.0.3",
+  "version": "6.0.0",
   "description": "UI component library for the XP platform.",
   "main": "lib/all.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "jest": "jest --roots=src",
     "start": "start-storybook -p 9001 -c .storybook -s public",
     "build": "cross-env NODE_ENV=production webpack --config webpack.standalone.js",
@@ -18,7 +18,6 @@
     "flow": "flow check src",
     "lint": "standard \"src/**/*.js\" \".jest/**/*.js\" \"jest.config.js\" \"__mocks__/**/*.js\" | snazzy",
     "lint-fix": "standard \"src/**/*.js\" \".jest/**/*.js\" \"jest.config.js\" \"__mocks__/**/*.js\" --fix | snazzy",
-    "prepublishOnly": "npm run build",
     "test": "npm run lint && npm run flow",
     "storybook:build": "build-storybook -c .storybook -o .storybook-static -s public"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x-team/xp-ui",
-  "version": "0.0.4",
+  "version": "6.0.0",
   "description": "UI component library for the XP platform.",
   "main": "lib/all.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "xp-ui",
-  "version": "2.0.0",
+  "name": "@x-team/xp-ui",
+  "version": "0.0.2",
   "description": "UI component library for the XP platform.",
   "main": "lib/all.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "doc": "docs"
   },
   "scripts": {
-    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "jest": "jest --roots=src",
     "start": "start-storybook -p 9001 -c .storybook -s public",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x-team/xp-ui",
-  "version": "0.0.4-dev",
+  "version": "0.0.4",
   "description": "UI component library for the XP platform.",
   "main": "lib/all.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "doc": "docs"
   },
   "scripts": {
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "jest": "jest --roots=src",
     "start": "start-storybook -p 9001 -c .storybook -s public",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "flow": "flow check src",
     "lint": "standard \"src/**/*.js\" \".jest/**/*.js\" \"jest.config.js\" \"__mocks__/**/*.js\" | snazzy",
     "lint-fix": "standard \"src/**/*.js\" \".jest/**/*.js\" \"jest.config.js\" \"__mocks__/**/*.js\" --fix | snazzy",
+    "prepublishOnly": "npm run build",
     "test": "npm run lint && npm run flow",
     "storybook:build": "build-storybook -c .storybook -o .storybook-static -s public"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x-team/xp-ui",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "UI component library for the XP platform.",
   "main": "lib/all.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x-team/xp-ui",
-  "version": "6.0.0",
+  "version": "0.0.3",
   "description": "UI component library for the XP platform.",
   "main": "lib/all.js",
   "files": [
@@ -19,6 +19,9 @@
     "lint": "standard \"src/**/*.js\" \".jest/**/*.js\" \"jest.config.js\" \"__mocks__/**/*.js\" | snazzy",
     "lint-fix": "standard \"src/**/*.js\" \".jest/**/*.js\" \"jest.config.js\" \"__mocks__/**/*.js\" --fix | snazzy",
     "test": "npm run lint && npm run flow",
+    "release-patch": "npm version patch",
+    "release-minor": "npm version minor",
+    "release-major": "npm version major",
     "storybook:build": "build-storybook -c .storybook -o .storybook-static -s public"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x-team/xp-ui",
-  "version": "0.0.4",
+  "version": "0.0.4-dev",
   "description": "UI component library for the XP platform.",
   "main": "lib/all.js",
   "files": [


### PR DESCRIPTION
**Release Type:** *Breaking Change* <!-- Refer to the wiki for more details https://github.com/x-team/xp/wiki/Release-Process#types-of-releases -->

**Related PRs:**

- https://github.com/x-team/xp/pull/2080
- https://github.com/x-team/xp-registration/pull/199

In this PR we scope the package to be `@x-team/xp-ui`, so that we can publish to npm as a public package, while still indicating that it is not intended for public use.

Note that I've set the version to `0.0.2`. This is so that while we are testing things we can republish without disrupting our current versioning system.

When we are ready to merge this I recommend setting the version to `6.0.0`. Then with every update we want to deploy we should use a sequence like:

```
npm version <patch,minor,major>
git push && git push --tags
npm publish --access public
```

This PR also requires some corresponding changes on the consumer side (eg. replace `import 'xp-ui/...` with `import '@x-team/xp-ui/...`) and this can be done with a project-wide search and replace.

Example of these changes in `xp-registration` here: https://github.com/x-team/xp-registration/pull/199

We would need to do a similar search-and-replace in the `xp` repo.