### PR TITLE
Replace "current" to "present" in WorkExperienceCard

### DIFF
--- a/src/components/ui/WorkExperienceCard.js
+++ b/src/components/ui/WorkExperienceCard.js
@@ -138,7 +138,7 @@ class WorkExperienceCard extends Component<Props> {
               : null
           }
 
-          {startDate && <div className={cx.dates}>{this.formatDate(startDate)} - {endDate ? this.formatDate(endDate) : 'Current'}</div>}
+          {startDate && <div className={cx.dates}>{this.formatDate(startDate)} - {endDate ? this.formatDate(endDate) : 'Present'}</div>}
 
           {
             (editEntry && deleteEntry)


### PR DESCRIPTION
<!--
Thank you for your pull request!

Provide a general summary of your changes in the Title above. Do not include any task numbers.
Use imperative, present tense capitalising the first letter: "Change" not "Changed" nor "changes". This will become a correct final merge commit message 😄
The imperative tells someone what merging the PR **will do**, rather than **what you did**.
An example: "Refactor code for readability".
-->

**Release Type:** *Bug Fix* <!-- Refer to the wiki for more details https://github.com/x-team/xp/wiki/Release-Process#types-of-releases -->
<!--
Basic types are:
  - Bug Fix (non-breaking change which fixes an issue)
  - Dev Improvement (these changes make life easier for devs but have no noticeable impact on end-users)
  - UI Improvement (visual UI changes that don't assume radical changes or extra new functionality)
  - Documentation (updating and/or enhancing existing documentation)
  - Non-Breaking Feature (adding a new feature without affecting any existing features)
  - Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-->

Fixes https://x-team-internal.atlassian.net/wiki/spaces/XD/pages/415170565/Sprint+79+Demo?focusedCommentId=451051643#comment-451051643

## Description

After present the DEMO for the WorkExperienceCard we got a request to change the word CURRENT to PRESENT for the cases when the endDate is not defined for an experience.

## Checklist

**Before submitting a Pull Request,** please make sure the following is done:

<!-- Remove items that do not apply and tick completed items in UI -->
- [X] set yourself as an assignee
- [X] set appropriate labels for a PR (`In Review` or `In Progress` depending on its status)
- [X] Flow typechecks passed (`npm run flow`)
- [x] Snapshots tests passed (`npm run jest`) (**NOTE:** This is temporarily disabled. Skip it.)
- [X] check cleanup tasks (https://github.com/x-team/xp/labels/cleanup) and take a suitable small one (if exists) in a related area of the current changes
- [x] if any snapshots have been changed, verify that component still works and looks as expected and update the changed snapshot (**NOTE:** This is temporarily disabled. Skip it.)

## Steps to Test or Reproduce

- Go to http://localhost:9001/?path=/story/ui-components-workexperiencecard-debug--without-enddate
- Confirm the word is `PRESENT` at the date section for when the endDate wasn't defined in the component

## Impacted Areas in Application

- src/components/ui/WorkExperienceCard.js

## Screenshots

![Screen Shot on 2020-05-15 at 00:29:55](https://user-images.githubusercontent.com/6010411/82011940-6c787e80-9644-11ea-917a-fa43d525ec20.png)

